### PR TITLE
Write fill attribute value if it differs from parent element

### DIFF
--- a/Source/Document Structure/SvgGroup.cs
+++ b/Source/Document Structure/SvgGroup.cs
@@ -26,7 +26,7 @@ namespace Svg
         [SvgAttribute("fill")]
         public override SvgPaintServer Fill
         {
-            get { return (this.Attributes["Fill"] == null) ? new SvgColourServer(Color.Transparent) : (SvgPaintServer)this.Attributes["Fill"]; }
+            get { return (this.Attributes["Fill"] == null) ? null : (SvgPaintServer)this.Attributes["Fill"]; }
             set { this.Attributes["Fill"] = value; }
         }
 

--- a/Source/Painting/SvgColourServer.cs
+++ b/Source/Painting/SvgColourServer.cs
@@ -67,7 +67,12 @@ namespace Svg
             if (objColor == null)
                 return false;
 
-            return this.Colour.ToArgb() == objColor.Colour.ToArgb();
+            return this.GetHashCode() == objColor.GetHashCode();
+        }
+
+        public override int GetHashCode()
+        {
+            return _colour.GetHashCode();
         }
     }
 }


### PR DESCRIPTION
If elements are nested in groups and have different fill values than
their containing group the fill value wouldn't be written correctly.
