### PR TITLE
Revert "Embedded transformations"

### DIFF
--- a/Source/SvgElement.cs
+++ b/Source/SvgElement.cs
@@ -170,7 +170,7 @@ namespace Svg
 
             foreach (SvgTransform transformation in this.Transforms)
             {
-                transformMatrix.Multiply(transformation.Matrix, MatrixOrder.Append);
+                transformMatrix.Multiply(transformation.Matrix);
             }
 
             renderer.Transform = transformMatrix;


### PR DESCRIPTION
This reverts commit 8c10c2e6070c4cadf391808fe9a679bed95e4249.

A.Multiply(B, Append) results in BA rather than AB.  Multiply without the MatrixOrder parameter will default to prepend which will result in AB to address Issue #10.
