### PR TITLE
offset of Gradient stop

### DIFF
--- a/Source/Painting/SvgGradientStop.cs
+++ b/Source/Painting/SvgGradientStop.cs
@@ -25,7 +25,32 @@ namespace Svg
             get { return this._offset; }
             set
             {
-                this._offset = value.ToPercentage();
+                SvgUnit unit = value;
+
+                if (value.Type == SvgUnitType.Percentage)
+                {
+                    if (value.Value > 100)
+                    {
+                        unit = new SvgUnit(value.Type, 100);
+                    }
+                    else if (value.Value < 0)
+                    {
+                        unit = new SvgUnit(value.Type, 0);
+                    }
+                }
+                else if (value.Type == SvgUnitType.User)
+                {
+                    if (value.Value > 1)
+                    {
+                        unit = new SvgUnit(value.Type, 1);
+                    }
+                    else if (value.Value < 0)
+                    {
+                        unit = new SvgUnit(value.Type, 0);
+                    }
+                }
+
+                this._offset = unit.ToPercentage();
             }
         }
 


### PR DESCRIPTION
http://www.w3.org/TR/SVG11/pservers.html#GradientStops

Gradient offset values less than 0 (or less than 0%) are rounded up to 0%. Gradient offset values greater than 1 (or greater than 100%) are rounded down to 100%.
