### PR TITLE
Support non standard features that modern browsers "standardized" on

### DIFF
--- a/Source/DataTypes/SvgUnitConverter.cs
+++ b/Source/DataTypes/SvgUnitConverter.cs
@@ -23,6 +23,13 @@ namespace Svg
                 throw new ArgumentOutOfRangeException("value must be a string.");
             }
 
+			//support exponents (the SVG that comes back from IE may be an exponent ugh!!!)
+			if ((value as string).Contains("e"))
+			{
+				var d = Decimal.Parse((string)value, System.Globalization.NumberStyles.Float);
+				value = d.ToString();
+			}
+
             // http://www.w3.org/TR/CSS21/syndata.html#values
             // http://www.w3.org/TR/SVG11/coords.html#Units
 

--- a/Source/Painting/SvgColourConverter.cs
+++ b/Source/Painting/SvgColourConverter.cs
@@ -38,9 +38,21 @@ namespace Svg
                     try
                     {
                         int start = colour.IndexOf("(") + 1;
-                        string[] values = colour.Substring(start, colour.IndexOf(")") - start).Split(new char[]{',', ' '}, StringSplitOptions.RemoveEmptyEntries);
+                        
+						//get the values from the RGB string
+						string[] values = colour.Substring(start, colour.IndexOf(")") - start).Split(new char[]{',', ' '}, StringSplitOptions.RemoveEmptyEntries);
 
-                        return System.Drawing.Color.FromArgb(int.Parse(values[0]), int.Parse(values[1]), int.Parse(values[2]));
+						//determine the alpha value if this is an RGBA (it will be the 4th value if there is one)
+						int alphaValue = 255;
+						if (values.Length > 3)
+						{
+							//the alpha portion of the rgba is not an int 0-255 it is a decimal between 0 and 1
+							//so we have to determine the corosponding byte value
+							alphaValue = (int)(decimal.Parse(values[3]) * 255);
+						}
+						Color colorpart = System.Drawing.Color.FromArgb(alphaValue, int.Parse(values[0]), int.Parse(values[1]), int.Parse(values[2]));
+
+						return colorpart;
                     }
                     catch
                     {

--- a/Source/SvgElementFactory.cs
+++ b/Source/SvgElementFactory.cs
@@ -134,6 +134,19 @@ namespace Svg
                         SetPropertyValue(element, style[0].Trim(), style[1].Trim(), document);
                     }
 
+					//defaults for text can come from the document
+					if (element.ElementName == "text")
+					{
+						if (!styles.Contains("font-size") && document.CustomAttributes.ContainsKey("font-size") && document.CustomAttributes["font-size"] != null)
+						{
+							SetPropertyValue(element, "font-size" , document.CustomAttributes["font-size"], document);
+						}
+						if (!styles.Contains("font-family") &&  document.CustomAttributes.ContainsKey("font-family") && document.CustomAttributes["font-family"] != null)
+						{
+							SetPropertyValue(element, "font-family", document.CustomAttributes["font-family"], document);
+						}
+						
+					}
                     continue; 
                 }
 
@@ -176,7 +189,14 @@ namespace Svg
 
                 try
                 {
-                    descriptor.SetValue(element, descriptor.Converter.ConvertFrom(document, CultureInfo.InvariantCulture, attributeValue));
+					if (attributeName == "opacity" && attributeValue == "undefined")
+					{
+						attributeValue = "1";
+					}
+
+					descriptor.SetValue(element, descriptor.Converter.ConvertFrom(document, CultureInfo.InvariantCulture, attributeValue));
+					
+
                 }
                 catch
                 {

--- a/Source/Text/SvgText.cs
+++ b/Source/Text/SvgText.cs
@@ -312,7 +312,8 @@ namespace Svg
             get
             {
                 // Make sure the path is always null if there is no text
-				if (string.IsNullOrWhiteSpace(this.Text))
+				//if there is a TSpan inside of this text element then path should not be null (even if this text is empty!)
+				if (string.IsNullOrWhiteSpace(this.Text) && this.Children.Where(x => x is SvgTextSpan).Select(x => x as SvgTextSpan).Count() == 0)
 				    return _path = null;
 				//NOT SURE WHAT THIS IS ABOUT - Path gets created again anyway - WTF?
                 // When an empty string is passed to GraphicsPath, it rises an InvalidArgumentException...


### PR DESCRIPTION
- RGBa support
- exponent support in units (IE sucks!)
- inherit font-size and font-family from root element on text elements
- allow empty text elements if there is a non empty TSPan
- added support for "undefined" opacity value (forgot to put this in the commit msg)
