### PR TITLE
Reading EntityReference on open when use as a node

### DIFF
--- a/Source/SvgDocument.cs
+++ b/Source/SvgDocument.cs
@@ -250,6 +250,10 @@ namespace Svg
                             case XmlNodeType.Text:
                                 value.Append(reader.Value);
                                 break;
+                            case XmlNodeType.EntityReference:
+                                reader.ResolveEntity();
+                                value.Append(reader.Value);
+                                break;
                         }
                     }
                     catch (Exception exc)


### PR DESCRIPTION
Read EntityReference node and add it to the SvgDocument.

Svg sample:

```
<?xml version="1.0"?>
<svg xmlns="http://www.w3.org/2000/svg" width="800px" height="800px">
  <g>
    <rect width="200px" height="200px" fill="black" />
    <text x="100px" y="100px" font-family="Verdana" font-size="24" fill="white" text-anchor="middle">&name;</text>
  </g>
</svg>
```
