### PR TITLE
Colors Fix, Perf Improvement, Thread Safety

### DIFF
--- a/Source/Painting/SvgColourConverter.cs
+++ b/Source/Painting/SvgColourConverter.cs
@@ -115,7 +115,7 @@ namespace Svg
             if (destinationType == typeof(string))
             {
                 var colour = (Color)value;
-                return ColorTranslator.ToHtml(colour);
+                return "#" + colour.R.ToString("X2", null) + colour.G.ToString("X2", null) + colour.B.ToString("X2", null);
             }
 
             return base.ConvertTo(context, culture, value, destinationType);

--- a/Source/Paths/SvgPathBuilder.cs
+++ b/Source/Paths/SvgPathBuilder.cs
@@ -276,7 +276,7 @@ namespace Svg
 
         private static IEnumerable<float> ParseCoordinates(string coords)
         {
-            var parts = Regex.Split(coords.Remove(0, 1), @"[\s,]|(?=(?<!e)-)");
+            var parts = Regex.Split(coords.Remove(0, 1), @"[\s,]|(?=(?<!e)-)", RegexOptions.Compiled);
 
             for (int i = 0; i < parts.Length; i++)
             {


### PR DESCRIPTION
-Fixes issues with colors not parsing correctly. Saving an SvgDocument
resulted in RGB color values being converted to well known color names.

-Compile regex statements to improve performance.

-Make rendering a document threadsafe.

cc @jameswelle 
