### PR TITLE
Fix for GDI crash if stroke-dasharray contains value<=0

### DIFF
--- a/Source/Basic Shapes/SvgVisualElement.cs
+++ b/Source/Basic Shapes/SvgVisualElement.cs
@@ -163,7 +163,7 @@ namespace Svg
                     if (this.StrokeDashArray != null && this.StrokeDashArray.Count > 0)
                     {
                         /* divide by stroke width - GDI behaviour that I don't quite understand yet.*/
-                        pen.DashPattern = this.StrokeDashArray.ConvertAll(u => u.Value/((strokeWidth <= 0) ? 1 : strokeWidth)).ToArray();
+                        pen.DashPattern = this.StrokeDashArray.ConvertAll(u => ((u.Value <= 0) ? 1 : u.Value) / ((strokeWidth <= 0) ? 1 : strokeWidth)).ToArray();
                     }
 
                     renderer.DrawPath(pen, this.Path);


### PR DESCRIPTION
Minor issue:

GDI Pen was crashing with some bad (Adobe Illustrator) data that had: `stroke-dasharray="10,10,0"`

Here is test case:

```
<?xml version="1.0" encoding="utf-8"?>
<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 
6.00 Build 0)  -->
<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
<svg version="1.1" id="Version_1.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="400px" height="400px" viewBox="0 0 400 400" enable-background="new 0 0 400 400" xml:space="preserve">
<g id="main">
    <rect x="8.25" y="54.25" fill="none" stroke="#000000" stroke-width="5" stroke-dasharray="10,10,0" width="282" height="282"/>
    <circle fill="none" stroke="#000000" stroke-width="5" cx="149.25"  cy="195.25" r="79.5"/>
</g>
</svg>
```
