### PR TITLE
Fix for null path

### DIFF
--- a/Source/Text/SvgTextBase.cs
+++ b/Source/Text/SvgTextBase.cs
@@ -296,10 +296,10 @@ namespace Svg
         public override GraphicsPath Path(ISvgRenderer renderer)
         {
             //if there is a TSpan inside of this text element then path should not be null (even if this text is empty!)
-            var nodes = GetContentNodes().Where(x => x is SvgContentNode)
-                                         .Select(n => !string.IsNullOrEmpty(n.Content.Trim(new[] {'\r', '\n', '\t'})));
+            var nodes = GetContentNodes().Where(x => x is SvgContentNode && 
+                                                     string.IsNullOrEmpty(x.Content.Trim(new[] {'\r', '\n', '\t'})));
             
-            if (_path == null || IsPathDirty || nodes.Any())
+            if (_path == null || IsPathDirty || nodes.Count() == 1)
             {
                 renderer = (renderer ?? SvgRenderer.FromNull());
                 SetPath(new TextDrawingState(renderer, this));


### PR DESCRIPTION
When passing in a string with just spaces " ", accessing SvgText.Bounds would throw a NullRef exception. The intent of this PR is to fix the nullref issue and allow for space strings.

I couldn't find any unit tests documenting this behaviour, so I'm not sure what the full impact of this change is. Based on the comments and historical commits, I believe this is the correct fix.
