### PR TITLE
fixed invalid font size unit comparison

### DIFF
--- a/Source/SvgElementStyle.cs
+++ b/Source/SvgElementStyle.cs
@@ -309,7 +309,7 @@ namespace Svg
             // Get the font-size
             float fontSize;
             var fontSizeUnit = this.FontSize;
-            if (fontSizeUnit == SvgUnit.None)
+            if (fontSizeUnit == SvgUnit.None || fontSizeUnit == SvgUnit.Empty)
             {
                 fontSize = 1.0f;
             }


### PR DESCRIPTION
Rendering text elements without a set font-size will render them with zero size (resulting in an exception) due to an invalid comparison against SvgUnit.None in SvgElementStyle. Comparing against SvgUnit.Empty instead fixes that.
