### PR TITLE
changed the default MatrixOrder to Prepend (instead of Append)

### DIFF
--- a/Source/Rendering/ISvgRenderer.cs
+++ b/Source/Rendering/ISvgRenderer.cs
@@ -15,12 +15,12 @@ namespace Svg
         ISvgBoundable GetBoundable();
         Region GetClip();
         ISvgBoundable PopBoundable();
-        void RotateTransform(float fAngle, MatrixOrder order = MatrixOrder.Append);
-        void ScaleTransform(float sx, float sy, MatrixOrder order = MatrixOrder.Append);
+        void RotateTransform(float fAngle, MatrixOrder order = MatrixOrder.Prepend);
+        void ScaleTransform(float sx, float sy, MatrixOrder order = MatrixOrder.Prepend);
         void SetBoundable(ISvgBoundable boundable);
         void SetClip(Region region, CombineMode combineMode = CombineMode.Replace);
         SmoothingMode SmoothingMode { get; set; }
         Matrix Transform { get; set; }
-        void TranslateTransform(float dx, float dy, MatrixOrder order = MatrixOrder.Append);
+        void TranslateTransform(float dx, float dy, MatrixOrder order = MatrixOrder.Prepend);
     }
 }

--- a/Source/Rendering/SvgRenderer.cs
+++ b/Source/Rendering/SvgRenderer.cs
@@ -62,11 +62,11 @@ namespace Svg
         {
             return this._innerGraphics.Clip;
         }
-        public void RotateTransform(float fAngle, MatrixOrder order = MatrixOrder.Append)
+        public void RotateTransform(float fAngle, MatrixOrder order)
         {
             this._innerGraphics.RotateTransform(fAngle, order);
         }
-        public void ScaleTransform(float sx, float sy, MatrixOrder order = MatrixOrder.Append)
+        public void ScaleTransform(float sx, float sy, MatrixOrder order)
         {
             this._innerGraphics.ScaleTransform(sx, sy, order);
         }
@@ -74,7 +74,7 @@ namespace Svg
         {
             this._innerGraphics.SetClip(region, combineMode);
         }
-        public void TranslateTransform(float dx, float dy, MatrixOrder order = MatrixOrder.Append)
+        public void TranslateTransform(float dx, float dy, MatrixOrder order)
         {
             this._innerGraphics.TranslateTransform(dx, dy, order);
         }


### PR DESCRIPTION
When rendering on a Graphics instance that already has transformations in place (e.g. scaling), the current default MatrixOrder.Append ignores these transforms. By changing the default to MatrixOrder.Prepend, preset transformations are applied correctly.
