### PR TITLE
HSL support, fix for clip path (issues 142 and 143)

### DIFF
--- a/Source/Basic Shapes/SvgVisualElement.cs
+++ b/Source/Basic Shapes/SvgVisualElement.cs
@@ -57,7 +57,7 @@ namespace Svg
         [SvgAttribute("clip-path")]
         public virtual Uri ClipPath
         {
-            get { return this.Attributes.GetInheritedAttribute<Uri>("clip-path"); }
+            get { return this.Attributes.GetAttribute<Uri>("clip-path"); }
             set { this.Attributes["clip-path"] = value; }
         }
 


### PR DESCRIPTION
Fixes for issue #142 and issue #143.  This may also fix another user's issue #123.
The first isse adds support for HSL color (e.g. fill="hsl( 100, 10%, 20% )").  The second fixes how SVG would copy clip-paths from parent to child even when the child had other transforms making the clip path invalid.  There's no need for it that I can see and it has the effect of corrupting loaded SVG.