### PR TITLE
FIxed #132  - rendering inline images

### DIFF
--- a/Source/Basic Shapes/SvgImage.cs
+++ b/Source/Basic Shapes/SvgImage.cs
@@ -251,7 +251,10 @@ namespace Svg
                 {
                     using (var stream = webResponse.GetResponseStream())
                     {
-                        stream.Position = 0;
+                        if (stream.CanSeek)
+                        {
+                            stream.Position = 0;    
+                        }
                         if (uri.LocalPath.EndsWith(".svg", StringComparison.InvariantCultureIgnoreCase))
                         {
                             var doc = SvgDocument.Open<SvgDocument>(stream);


### PR DESCRIPTION
Fixed issue #132 where rendering inline images failed because of an attempt to seek on the web response stream.
Added a condition to check if the stream can seek. 