### PR TITLE
Fix to #173: Sub elements in group element are not rendered

### DIFF
--- a/Source/SvgElement.cs
+++ b/Source/SvgElement.cs
@@ -800,9 +800,14 @@ namespace Svg
         			}
         			else
         			{
-                        var childPath = GetPaths(child, renderer);
-        				if(child.Transforms != null)
-        					childPath.Transform(child.Transforms.GetMatrix());
+				        var childPath = GetPaths(child, renderer);
+        				if (childPath != null && childPath.PointCount > 0)
+        				{
+        					if (child.Transforms != null)
+						        childPath.Transform(child.Transforms.GetMatrix());
+                  
+					        ret.AddPath(childPath, false);
+				        }
         			}
         		}
         			


### PR DESCRIPTION
It was weird that in case of group element, its nested elements' calculated paths are not added to return value of recursive method GetPaths(). 