### PR TITLE
Fixed problems when running in multiple threads

### DIFF
--- a/Source/Exceptions/SvgMemoryException.cs
+++ b/Source/Exceptions/SvgMemoryException.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace Svg.Exceptions
+{
+	[Serializable]
+	public class SvgMemoryException : Exception
+	{
+		public SvgMemoryException() {}
+		public SvgMemoryException(string message) : base(message) {}
+		public SvgMemoryException(string message, Exception inner) : base(message, inner) {}
+
+		protected SvgMemoryException(
+			SerializationInfo info,
+			StreamingContext context) : base(info, context) {}
+	}
+}

--- a/Source/Svg.csproj
+++ b/Source/Svg.csproj
@@ -107,6 +107,7 @@
     <Compile Include="DataTypes\SvgTextPathSpacing.cs" />
     <Compile Include="DataTypes\XmlSpaceHandling.cs" />
     <Compile Include="Document Structure\SvgSymbol.cs" />
+    <Compile Include="Exceptions\SvgMemoryException.cs" />
     <Compile Include="ExtensionMethods\UriExtensions.cs" />
     <Compile Include="Filter Effects\ImageBuffer.cs" />
     <Compile Include="Painting\GenericBoundable.cs" />

--- a/Source/SvgDocument.cs
+++ b/Source/SvgDocument.cs
@@ -13,6 +13,7 @@ using ExCSS;
 using Svg.Css;
 using System.Threading;
 using System.Globalization;
+using Svg.Exceptions;
 
 namespace Svg
 {
@@ -434,17 +435,27 @@ namespace Svg
             this.Render(renderer);
         }
 
-        /// <summary>
-        /// Renders the <see cref="SvgDocument"/> and returns the image as a <see cref="Bitmap"/>.
-        /// </summary>
-        /// <returns>A <see cref="Bitmap"/> containing the rendered document.</returns>
-        public virtual Bitmap Draw()
-        {
-            //Trace.TraceInformation("Begin Render");
+	    /// <summary>
+	    /// Renders the <see cref="SvgDocument"/> and returns the image as a <see cref="Bitmap"/>.
+	    /// </summary>
+	    /// <returns>A <see cref="Bitmap"/> containing the rendered document.</returns>
+	    public virtual Bitmap Draw()
+	    {
+		    //Trace.TraceInformation("Begin Render");
 
-            var size = GetDimensions();
-            var bitmap = new Bitmap((int)Math.Round(size.Width), (int)Math.Round(size.Height));
-            // 	bitmap.SetResolution(300, 300);
+		    var size = GetDimensions();
+		    Bitmap bitmap = null;
+		    try
+		    {
+			    bitmap = new Bitmap((int) Math.Round(size.Width), (int) Math.Round(size.Height));
+		    }
+		    catch (ArgumentException e)
+		    {
+				//When processing too many files at one the system can run out of memory
+			    throw new SvgMemoryException("Cannot process SVG file, cannot allocate the required memory", e);
+		    }
+
+	    // 	bitmap.SetResolution(300, 300);
             try
             {
                 Draw(bitmap);

--- a/Source/SvgElement.cs
+++ b/Source/SvgElement.cs
@@ -284,7 +284,7 @@ namespace Svg
             get { return this._customAttributes; }
         }
 
-        private static readonly Matrix _zeroMatrix = new Matrix(0, 0, 0, 0, 0, 0);
+        private readonly Matrix _zeroMatrix = new Matrix(0, 0, 0, 0, 0, 0);
 
         /// <summary>
         /// Applies the required transforms to <see cref="ISvgRenderer"/>.

--- a/Source/Text/GdiFontDefn.cs
+++ b/Source/Text/GdiFontDefn.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Drawing;
@@ -58,15 +59,15 @@ namespace Svg
 
         public SizeF MeasureString(ISvgRenderer renderer, string text)
         {
-            var g = GetGraphics(renderer);
-            StringFormat format = StringFormat.GenericTypographic;
-            format.SetMeasurableCharacterRanges(new CharacterRange[] { new CharacterRange(0, text.Length) });
-            format.FormatFlags |= StringFormatFlags.MeasureTrailingSpaces;
-            Region[] r = g.MeasureCharacterRanges(text, _font, new Rectangle(0, 0, 1000, 1000), format);
-            RectangleF rect = r[0].GetBounds(g);
+		    var g = GetGraphics(renderer);
+		    StringFormat format = StringFormat.GenericTypographic.Clone() as StringFormat;
+		    format.SetMeasurableCharacterRanges(new CharacterRange[] {new CharacterRange(0, text.Length)});
+		    format.FormatFlags |= StringFormatFlags.MeasureTrailingSpaces;
+			Region[] r = g.MeasureCharacterRanges(text, _font, new Rectangle(0, 0, 1000, 1000), format);
+			RectangleF rect = r[0].GetBounds(g);
 
-            return new SizeF(rect.Width, Ascent(renderer));
-        }
+			return new SizeF(rect.Width, Ascent(renderer));
+		}
 
         private Graphics _graphics;
         private Graphics GetGraphics(object renderer)

--- a/Tests/Svg.UnitTests/MultiThreadingTest.cs
+++ b/Tests/Svg.UnitTests/MultiThreadingTest.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Threading.Tasks;
 using System.Xml;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Svg.Exceptions;
 
 namespace Svg.UnitTests
 {
@@ -34,12 +35,28 @@ namespace Svg.UnitTests
 		public void TestMultiThread()
 		{
 			bool valid = true;
-			Parallel.For(0, 3, (x) =>
+			Parallel.For(0, 10, (x) =>
 			{
 				LoadFile();
-			});
-			Assert.IsTrue(valid, "One or more of the runs was invalid");
+			});			
 			Trace.WriteLine("Done");
+		}
+
+		[TestMethod]
+		[ExpectedException(typeof(SvgMemoryException))]
+		public void SVGGivesMemoryExceptionOnTooManyParallelTest()
+		{
+			try
+			{
+				Parallel.For(0, 50, (x) =>
+				{
+					LoadFile();
+				});
+			}
+			catch (AggregateException ex)
+			{
+				throw ex.InnerException;
+			}
 		}
 		private void LoadFile()
 		{


### PR DESCRIPTION
Fixed problems when running in multiple threads. The use of a static matrix and the use of StringFormat.GenericTypographic seemed to cause problems when used in multi-threading. This is resolved by making the matrix non static and use a copy of the StringFormat.

Also created a new exception for memory overflows. When using multithreading to render a large amount of big images the bitmap creation can fail (due to memory allocation) throwing an error. This is now caught and a specific exception is thrown.

This will fix issue: #59 