### PR TITLE
Fix #185: Multiline text is not rendered. 

### DIFF
--- a/Source/SvgElement.cs
+++ b/Source/SvgElement.cs
@@ -789,6 +789,10 @@ namespace Svg
         			{
                         var childPath = ((SvgVisualElement)child).Path(renderer);
         				
+      					// Non-group element can have child element which we have to consider. i.e tspan in text element
+      					if (child.Children.Count > 0)
+    				  		childPath.AddPath(GetPaths(child, renderer), false);
+
         				if (childPath != null && childPath.PointCount > 0)
         				{
         					childPath = (GraphicsPath)childPath.Clone();


### PR DESCRIPTION
GetPaths method made recursive call to children of only group element. So, it was not calculating path for tspan element which is nested/child element to text element (non-group). This is why multi-line texts were not rendered. Now GetPaths will call non-group elements' child if there is any. And texts are rendered correctly