### PR TITLE
Fix calculation of rectangle path

### DIFF
--- a/Source/Basic Shapes/SvgRectangle.cs
+++ b/Source/Basic Shapes/SvgRectangle.cs
@@ -193,8 +193,8 @@ namespace Svg
                   // Starting location which take consideration of stroke width
                   SvgPoint strokedLocation = new SvgPoint(Location.X - halfStrokeWidth, Location.Y - halfStrokeWidth);
 
-                  var width = this.Width.ToDeviceValue(renderer, UnitRenderingType.Horizontal, this) + base.StrokeWidth;
-                  var height = this.Height.ToDeviceValue(renderer, UnitRenderingType.Vertical, this) + base.StrokeWidth;
+                  var width = this.Width.ToDeviceValue(renderer, UnitRenderingType.Horizontal, this) + halfStrokeWidth;
+                  var height = this.Height.ToDeviceValue(renderer, UnitRenderingType.Vertical, this) + halfStrokeWidth;
                   
                   var rectangle = new RectangleF(strokedLocation.ToDeviceValue(renderer, this), new SizeF(width, height));
 


### PR DESCRIPTION
The rectangle path width/height was computed using the full stroke width. It should have been using the half stroke width instead.

Consider this SVG image:

```
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<svg
   xmlns:dc="http://purl.org/dc/elements/1.1/"
   xmlns:cc="http://creativecommons.org/ns#"
   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
   xmlns:svg="http://www.w3.org/2000/svg"
   xmlns="http://www.w3.org/2000/svg"
   viewBox="0 0 256 256"
   version="1.1"
   id="svg2"
   height="256"
   width="256">
  <defs
     id="defs4" />
  <metadata
     id="metadata7">
    <rdf:RDF>
      <cc:Work
         rdf:about="">
        <dc:format>image/svg+xml</dc:format>
        <dc:type
           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
        <dc:title></dc:title>
      </cc:Work>
    </rdf:RDF>
  </metadata>
  <g
     id="layer1">
    <rect
       y="8"
       x="8"
       height="240"
       width="240"
       id="rect4136"
       style="opacity:1;fill:#61abff;fill-opacity:1;stroke:#002858;stroke-width:16;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
  </g>
</svg>
```

It is supposed to look like a blue rectangle with a darker blue stroke around it.

![Expected image](https://cloud.githubusercontent.com/assets/12978641/10212386/7b3f9b3e-67cc-11e5-9f44-bbbdaef4ee80.png)

However, the following code produces a bitmap with the bottom and right portions of the stroke cut off:

```
string svgFileName = "path/to/file"
var doc = SvgDocument.Open(svgFileName);
var bmp = doc.Draw();
```

![Actual image](https://cloud.githubusercontent.com/assets/12978641/10212390/81a0750c-67cc-11e5-93ff-7817ca93d12b.png)

Adjusting the rectangle path calculation to add the half stroke width, instead of the full stroke width, to the total rectangle width/height resolves this issue.
