### PR TITLE
Split by comma, remove space in the end

### DIFF
--- a/Source/DataTypes/SvgUnitCollection.cs
+++ b/Source/DataTypes/SvgUnitCollection.cs
@@ -15,13 +15,7 @@ namespace Svg
     {
         public override string ToString()
         {
-            string ret = "";
-            foreach (var unit in this)
-            {
-                ret += unit.ToString() + " ";
-            }
-
-            return ret;
+            return String.Join(",", this.Select(u => u.ToString()).ToArray());
         }
 
         public static bool IsNullOrEmpty(SvgUnitCollection collection)


### PR DESCRIPTION
This is the fix of the ending space in the text coordinates as well as stroke-dasharray delimiter (should be comma). This fix would allow to render text and dashed paths using [Magick.NET](https://magick.codeplex.com/) while converting to other formats.
