### PR TITLE
Update to fix Draw(Height,Width) overload

### DIFF
--- a/Source/SvgDocument.cs
+++ b/Source/SvgDocument.cs
@@ -486,9 +486,10 @@ namespace Svg
 					//EO, 2014-12-05: Requested to ensure proper zooming (draw the svg in the bitmap size, ==> proper scaling)
 					//EO, 2015-01-09, Added GetDimensions to use its returned size instead of this.Width and this.Height (request of Icarrere).
 
-          //BBN, 2015-07-29, it is unnecassary to call again GetDimensions and transform to 1x1
-          //SizeF size = this.GetDimensions();
-					//renderer.ScaleTransform(bitmap.Width / size.Width, bitmap.Height / size.Height);
+                    //BBN, 2015-07-29, it is unnecassary to call again GetDimensions and transform to 1x1
+                    //JA, 2015-12-18, this is actually necessary to correctly render the Draw(rasterHeight, rasterWidth) overload, otherwise the rendered graphic doesn't scale correctly
+                    SizeF size = this.GetDimensions();
+					renderer.ScaleTransform(bitmap.Width / size.Width, bitmap.Height / size.Height);
 
 					//EO, 2014-12-05: Requested to ensure proper zooming out (reduce size). Otherwise it clip the image.
 					this.Overflow = SvgOverflow.Auto;


### PR DESCRIPTION
Uncommenting lines that were commented previously because they are required to properly render the Draw(Height,Width) overload at the correct scale (rather than only rendering the top x, y of the image).