### PR TITLE
[bugfix] now pattern reads proper transform named "patternTransform"

### DIFF
--- a/Source/Painting/SvgPatternServer.cs
+++ b/Source/Painting/SvgPatternServer.cs
@@ -131,8 +131,8 @@ namespace Svg
         [SvgAttribute("patternTransform")]
         public SvgTransformCollection PatternTransform
         {
-            get { return (this.Attributes.GetAttribute<SvgTransformCollection>("gradientTransform")); }
-            set { this.Attributes["gradientTransform"] = value; }
+            get { return (this.Attributes.GetAttribute<SvgTransformCollection>("patternTransform")); }
+            set { this.Attributes["patternTransform"] = value; }
         }
 
         private Matrix EffectivePatternTransform


### PR DESCRIPTION
now pattern reads proper transform named "patternTransform"

- reference: https://developer.mozilla.org/en-US/docs/Web/SVG/Element/pattern