### PR TITLE
Fix stack overflow exception for em font-size value type

### DIFF
--- a/Source/DataTypes/SvgUnit.cs
+++ b/Source/DataTypes/SvgUnit.cs
@@ -180,9 +180,8 @@ namespace Svg
         private IFontDefn GetFont(ISvgRenderer renderer, SvgElement owner)
         {
             if (owner == null) return null;
-
-            var visual = owner.ParentsAndSelf.OfType<SvgVisualElement>().FirstOrDefault();
-            return visual.GetFont(renderer);
+            var visual = owner.Parents.OfType<SvgVisualElement>().FirstOrDefault();
+            return visual?.GetFont(renderer);
         }
 
         /// <summary>


### PR DESCRIPTION
Hello, I found a critical bug, if svg attribute font-size set to enter values measurement units "em", then we get stackoverflow exception. Try to draw this svg -

```
<svg>
<text font-size = "2em"> Some Text </text>
</svg>
```
