### PR TITLE
Fix fill-opacity/stroke-opacity wrongly inheriting from opacity when …

### DIFF
--- a/Source/SvgElementStyle.cs
+++ b/Source/SvgElementStyle.cs
@@ -66,7 +66,7 @@ namespace Svg
         [SvgAttribute("fill-opacity", true)]
         public virtual float FillOpacity
         {
-            get { return (float)(this.Attributes["fill-opacity"] ?? this.Opacity); }
+            get { return (float)(this.Attributes["fill-opacity"] ?? 1.0f); }
             set { this.Attributes["fill-opacity"] = FixOpacityValue(value); }
         }
 
@@ -121,7 +121,7 @@ namespace Svg
         [SvgAttribute("stroke-opacity", true)]
         public virtual float StrokeOpacity
         {
-            get { return (float)(this.Attributes["stroke-opacity"] ?? this.Opacity); }
+            get { return (float)(this.Attributes["stroke-opacity"] ?? 1.0f); }
             set { this.Attributes["stroke-opacity"] = FixOpacityValue(value); }
         }
 


### PR DESCRIPTION
Hey,

This is Tammo from Ventuz - we have just begun to use your SVG library for our products.
One thing that occured during testing was that the opacity attribute came out wrong because it was copied to the fill-opacity and stroke-opacity attributes when the latter were not specified, resulting in accidentally applying the opacity twice in the end.

I checked against the specs and compared rendering to Firefox and Edge, and treating fill-opacity and stroke-opacity separate from opacity seems to be the right way.

Test case is attached.

[opacitytest.zip](https://github.com/vvvv/SVG/files/337218/opacitytest.zip)
