### PR TITLE
SvgPointCollection ToString method fix

### DIFF
--- a/Source/DataTypes/SvgPointCollection.cs
+++ b/Source/DataTypes/SvgPointCollection.cs
@@ -15,13 +15,22 @@ namespace Svg
     {
         public override string ToString()
         {
-            string ret = "";
-            foreach (var unit in this)
+            var builder = new StringBuilder();
+            for (var i = 0; i < Count; i += 2) 
             {
-                ret += unit.ToString() + " ";
+                if (i + 1 < Count) 
+                {
+                    if (i > 1) 
+                    {
+                        builder.Append(" ");
+                    }
+                    // we don't need unit type
+                    builder.Append(this[i].Value.ToString(CultureInfo.InvariantCulture));
+                    builder.Append(",");
+                    builder.Append(this[i + 1].Value.ToString(CultureInfo.InvariantCulture));
+                }    
             }
-
-            return ret;
+            return builder.ToString();
         }
     }
 

--- a/Tests/Svg.UnitTests/Svg.UnitTests.csproj
+++ b/Tests/Svg.UnitTests/Svg.UnitTests.csproj
@@ -62,6 +62,7 @@
     <Compile Include="PrivateFontsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SmallEmbeddingImageTest.cs" />
+    <Compile Include="SvgPointCollectionTests.cs" />
     <Compile Include="SvgTestHelper.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Tests/Svg.UnitTests/SvgPointCollectionTests.cs
+++ b/Tests/Svg.UnitTests/SvgPointCollectionTests.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Svg.UnitTests {
+
+    [TestClass]
+    public class SvgPointCollectionTests 
+    {
+
+        [TestMethod]
+        public void ToStringReturnsValidString() 
+        {
+            var collection = new SvgPointCollection 
+            {
+                new SvgUnit(1.6f), new SvgUnit(3.2f),
+                new SvgUnit(1.2f), new SvgUnit(5f)
+            };
+            Assert.AreEqual("1.6,3.2 1.2,5", collection.ToString());
+        }
+    }
+}


### PR DESCRIPTION
**SvgPointCollection.ToString** now produce valid svg coordinate string. This fixes an issue when polylines and polygons (when converted to svg document file) were not rendering correctly due to their "points" attribute value was incorrectly formatted.

Now
- Each value pair is separated by whitespace and their x and y values - by comma. 
- No unit type is written to output string
