### PR TITLE
Circle, ellipse, polygon and rectangle render correctly when their stroke-width is set to zero

### DIFF
--- a/Source/Basic Shapes/SvgCircle.cs
+++ b/Source/Basic Shapes/SvgCircle.cs
@@ -89,7 +89,7 @@ namespace Svg
         /// </summary>
         public override GraphicsPath Path(ISvgRenderer renderer)
         {
-            if ((this._path == null || this.IsPathDirty)	&& base.StrokeWidth > 0)
+            if (this._path == null || this.IsPathDirty)
             {
 							float halfStrokeWidth = base.StrokeWidth / 2;
 

--- a/Source/Basic Shapes/SvgEllipse.cs
+++ b/Source/Basic Shapes/SvgEllipse.cs
@@ -95,7 +95,7 @@ namespace Svg
         /// <value></value>
         public override GraphicsPath Path(ISvgRenderer renderer)
         {
-            if ((this._path == null || this.IsPathDirty) && base.StrokeWidth > 0)
+            if (this._path == null || this.IsPathDirty)
             {
 							float halfStrokeWidth = base.StrokeWidth / 2;
 

--- a/Source/Basic Shapes/SvgPolygon.cs
+++ b/Source/Basic Shapes/SvgPolygon.cs
@@ -61,7 +61,7 @@ namespace Svg
 
         public override GraphicsPath Path(ISvgRenderer renderer)
         {
-            if ((this._path == null || this.IsPathDirty)	&& base.StrokeWidth > 0)
+            if (this._path == null || this.IsPathDirty)
             {
                 this._path = new GraphicsPath();
                 this._path.StartFigure();

--- a/Source/Basic Shapes/SvgRectangle.cs
+++ b/Source/Basic Shapes/SvgRectangle.cs
@@ -182,7 +182,7 @@ namespace Svg
         /// </summary>
         public override GraphicsPath Path(ISvgRenderer renderer)
         {
-            if ((_path == null || IsPathDirty) && base.StrokeWidth > 0)
+            if (_path == null || IsPathDirty)
             {
                 var halfStrokeWidth = new SvgUnit(base.StrokeWidth / 2);
 

--- a/Source/Basic Shapes/SvgVisualElement.cs
+++ b/Source/Basic Shapes/SvgVisualElement.cs
@@ -215,7 +215,7 @@ namespace Svg
         /// <param name="renderer">The <see cref="ISvgRenderer"/> object to render to.</param>
         protected internal virtual bool RenderStroke(ISvgRenderer renderer)
         {
-            if (this.Stroke != null && this.Stroke != SvgColourServer.None)
+            if (this.Stroke != null && this.Stroke != SvgColourServer.None && this.StrokeWidth > 0)
             {
                 float strokeWidth = this.StrokeWidth.ToDeviceValue(renderer, UnitRenderingType.Other, this);
                 using (var brush = this.Stroke.GetBrush(this, renderer, Math.Min(Math.Max(this.StrokeOpacity * this.Opacity, 0), 1), true))


### PR DESCRIPTION
I've fixed strange behaviour when circle, ellipse, polygon and rectangle will not render if their StrokeWidth is less or equal zero. I removed this check from their Path overrides and moved it to their base class's (SvgVisualElement) RenderStroke method.

- Now stroke won't be rendered in any ancestor of SvgVisualElement that has StrokeWidth  <= 0.
- Circle, ellipse, polygon and rectangle will render only their fill if StrokeWidth  <= 0.

fixes #256