### PR TITLE
Proper SvgTextBase.Text property setter behaviour

### DIFF
--- a/Source/Text/SvgTextBase.cs
+++ b/Source/Text/SvgTextBase.cs
@@ -26,7 +26,16 @@ namespace Svg
         public virtual string Text
         {
             get { return base.Content; }
-            set { base.Content = value; this.IsPathDirty = true; this.Content = value; }
+            set {
+                Nodes.Clear();
+                Children.Clear();
+                if(value != null)
+                {
+                    Nodes.Add(new SvgContentNode { Content = value });
+                }
+                this.IsPathDirty = true;
+                Content = value;
+            }
         }
 
         /// <summary>

--- a/Tests/Svg.UnitTests/Svg.UnitTests.csproj
+++ b/Tests/Svg.UnitTests/Svg.UnitTests.csproj
@@ -64,6 +64,7 @@
     <Compile Include="SmallEmbeddingImageTest.cs" />
     <Compile Include="SvgPointCollectionTests.cs" />
     <Compile Include="SvgTestHelper.cs" />
+    <Compile Include="SvgTextTests.cs" />
     <Compile Include="SvgTextElementDeepCopyTest.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Tests/Svg.UnitTests/SvgTextTests.cs
+++ b/Tests/Svg.UnitTests/SvgTextTests.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml;
+
+namespace Svg.UnitTests
+{
+    [TestClass]
+    public class SvgTextTests
+    {
+
+        [TestMethod]
+        public void TextPropertyAffectsSvgOutput()
+        {
+            var document = new SvgDocument();
+            document.Children.Add(new SvgText { Text = "test1" });
+            using(var stream = new MemoryStream())
+            {
+                document.Write(stream);
+                stream.Position = 0;
+
+                var xmlDoc = new XmlDocument();
+                xmlDoc.Load(stream);
+                Assert.AreEqual("test1", xmlDoc.DocumentElement.FirstChild.InnerText);
+            }
+        }
+    }
+}


### PR DESCRIPTION
SvgTextBase.Text property setter resets Node (and Children) collection to have single content node with provided text.
Text elements must have at least one node to be serialized. Serializer is ignoring Content property of text elements, so Text property resets any previous text (by removing content Nodes) and creates a new node containing provided text.

fixes #259
fixes #254
fixes #151