### PR TITLE
Revert "Fix #176: Blurry text when overlapped with colored background"

### DIFF
--- a/Samples/SVGViewer/DebugRenderer.cs
+++ b/Samples/SVGViewer/DebugRenderer.cs
@@ -93,11 +93,7 @@ namespace SVGViewer
             _transform.Translate(dx, dy, order);
         }
 
-        public CompositingMode CompositingMode
-        {
-          get { return System.Drawing.Drawing2D.CompositingMode.SourceOver; /* default value */ }
-          set { /* Do Nothing */ }
-        }
+
 
         public SmoothingMode SmoothingMode
         {

--- a/Source/Rendering/ISvgRenderer.cs
+++ b/Source/Rendering/ISvgRenderer.cs
@@ -19,7 +19,6 @@ namespace Svg
         void ScaleTransform(float sx, float sy, MatrixOrder order = MatrixOrder.Append);
         void SetBoundable(ISvgBoundable boundable);
         void SetClip(Region region, CombineMode combineMode = CombineMode.Replace);
-        CompositingMode CompositingMode { get; set; }
         SmoothingMode SmoothingMode { get; set; }
         Matrix Transform { get; set; }
         void TranslateTransform(float dx, float dy, MatrixOrder order = MatrixOrder.Append);

--- a/Source/Rendering/SvgRenderer.cs
+++ b/Source/Rendering/SvgRenderer.cs
@@ -79,11 +79,7 @@ namespace Svg
             this._innerGraphics.TranslateTransform(dx, dy, order);
         }
         
-        public CompositingMode CompositingMode
-        {
-          get { return this._innerGraphics.CompositingMode; }
-          set { this._innerGraphics.CompositingMode = value; }
-        }
+
 
         public SmoothingMode SmoothingMode
         {

--- a/Source/Text/SvgTextBase.cs
+++ b/Source/Text/SvgTextBase.cs
@@ -259,11 +259,6 @@ namespace Svg
                     renderer.SmoothingMode = SmoothingMode.AntiAlias;
                 }
 
-                // If text color blends with background color, text will be rendered blurry
-                // To avoid it, we set SourceCopy which overwrite background color
-                var compositingMode = renderer.CompositingMode;
-                renderer.CompositingMode = CompositingMode.SourceCopy;
-
                 this.RenderFill(renderer);
                 this.RenderStroke(renderer);
                 this.RenderChildren(renderer);
@@ -273,8 +268,6 @@ namespace Svg
                 {
                     renderer.SmoothingMode = SmoothingMode.Default;
                 }
-
-                renderer.CompositingMode = compositingMode;
 
                 this.ResetClip(renderer);
                 this.PopTransforms(renderer);


### PR DESCRIPTION
Reverts vvvv/SVG#198 so there is no more text artefacts over colored background