### PR TITLE
Added array caching to AddToPath for a significant performance increase.

### DIFF
--- a/Source/Paths/SvgClosePathSegment.cs
+++ b/Source/Paths/SvgClosePathSegment.cs
@@ -9,13 +9,17 @@ namespace Svg.Pathing
         public override void AddToPath(System.Drawing.Drawing2D.GraphicsPath graphicsPath)
         {
             // Important for custom line caps.  Force the path the close with an explicit line, not just an implicit close of the figure.
-            if (graphicsPath.PointCount > 0 && !graphicsPath.PathPoints[0].Equals(graphicsPath.PathPoints[graphicsPath.PathPoints.Length - 1]))
+            var pathPoints = graphicsPath.PathPoints;
+
+            if (pathPoints.Length > 0 && !pathPoints[0].Equals(pathPoints[pathPoints.Length - 1]))
             {
-                int i = graphicsPath.PathTypes.Length - 1;
-                while (i >= 0 && graphicsPath.PathTypes[i] > 0) i--;
+                var pathTypes = graphicsPath.PathTypes;
+                int i = pathPoints.Length - 1;
+                while (i >= 0 && pathTypes[i] > 0) i--;
                 if (i < 0) i = 0;
-                graphicsPath.AddLine(graphicsPath.PathPoints[graphicsPath.PathPoints.Length - 1], graphicsPath.PathPoints[i]);
+                graphicsPath.AddLine(pathPoints[pathPoints.Length - 1], pathPoints[i]);
             }
+
             graphicsPath.CloseFigure();
         }
 


### PR DESCRIPTION
Every time you index graphicsPath.PathPoints or graphicsPath.PathTypes the accessor rebuilds the arrays and makes dll calls, graphicsPath.PointCount also makes dll calls. this is fixed by simply assigning the arrays to local variables and using them from there. Using this [SVG](https://upload.wikimedia.org/wikipedia/commons/e/e8/Dualshock_4_Layout.svg) as an example it reduces the render time from 12-13 seconds to 1-2 seconds.