### PR TITLE
Use Hidden as default SvgOverflow value

### DIFF
--- a/Source/DataTypes/SvgOverflow.cs
+++ b/Source/DataTypes/SvgOverflow.cs
@@ -21,6 +21,9 @@ namespace Svg
     [TypeConverter(typeof(SvgOverflowConverter))]
 	public enum SvgOverflow
     {
+        /// <summary>Overflow is not rendered.</summary>
+        Hidden,
+
         /// <summary>The value is inherited from the parent element.</summary>
 		Inherit,
 
@@ -29,9 +32,6 @@ namespace Svg
 
         /// <summary>Overflow is rendered.</summary>
         Visible,
-
-        /// <summary>Overflow is not rendered.</summary>
-        Hidden,
 
         /// <summary>Overflow causes a scrollbar to appear (horizontal, vertical or both).</summary>
 		Scroll


### PR DESCRIPTION
- changes behavior to be as described in this file and in the W3C test
masking-path-03-b
- fixes that test
- this has been a regression after removing the unconditional clip box
for every view box, (see #279)