### PR TITLE
Found better solution to SvgClosePathSegment tested with Tiger.

### DIFF
--- a/Source/Paths/SvgClosePathSegment.cs
+++ b/Source/Paths/SvgClosePathSegment.cs
@@ -8,24 +8,22 @@ namespace Svg.Pathing
     {
         public override void AddToPath(System.Drawing.Drawing2D.GraphicsPath graphicsPath)
         {
-            if (graphicsPath.PointCount == 0)
+            var pathData = graphicsPath.PathData;
+
+            if (pathData.Points.Length > 0)
             {
-                return;
+                // Important for custom line caps.  Force the path the close with an explicit line, not just an implicit close of the figure.
+
+                if (!pathData.Points[0].Equals(pathData.Points[pathData.Points.Length - 1]))
+                {
+                    int i = pathData.Points.Length - 1;
+                    while (i >= 0 && pathData.Types[i] > 0) i--;
+                    if (i < 0) i = 0;
+                    graphicsPath.AddLine(pathData.Points[pathData.Points.Length - 1], pathData.Points[i]);
+                }
+
+                graphicsPath.CloseFigure();
             }
-
-            // Important for custom line caps.  Force the path the close with an explicit line, not just an implicit close of the figure.
-            var pathPoints = graphicsPath.PathPoints;
-
-            if (!pathPoints[0].Equals(pathPoints[pathPoints.Length - 1]))
-            {
-                var pathTypes = graphicsPath.PathTypes;
-                int i = pathPoints.Length - 1;
-                while (i >= 0 && pathTypes[i] > 0) i--;
-                if (i < 0) i = 0;
-                graphicsPath.AddLine(pathPoints[pathPoints.Length - 1], pathPoints[i]);
-            }
-
-            graphicsPath.CloseFigure();
         }
 
         public override string ToString()


### PR DESCRIPTION
PathData doesn't throw an exception when PointCount is 0 and gets the points and types at the same time. tested it with Tiger and everything seems to be working.