### PR TITLE
Fix scaling of Draw(width, height)

### DIFF
--- a/Source/SvgDocument.cs
+++ b/Source/SvgDocument.cs
@@ -483,13 +483,6 @@ namespace Svg
 				{
 					renderer.SetBoundable(new GenericBoundable(0, 0, bitmap.Width, bitmap.Height));
 
-					//EO, 2014-12-05: Requested to ensure proper zooming (draw the svg in the bitmap size, ==> proper scaling)
-					//EO, 2015-01-09, Added GetDimensions to use its returned size instead of this.Width and this.Height (request of Icarrere).
-                    //BBN, 2015-07-29, it is unnecassary to call again GetDimensions and transform to 1x1
-                    //JA, 2015-12-18, this is actually necessary to correctly render the Draw(rasterHeight, rasterWidth) overload, otherwise the rendered graphic doesn't scale correctly
-                    SizeF size = this.GetDimensions();
-					renderer.ScaleTransform(bitmap.Width / size.Width, bitmap.Height / size.Height);
-
 					//EO, 2014-12-05: Requested to ensure proper zooming out (reduce size). Otherwise it clip the image.
 					this.Overflow = SvgOverflow.Auto;
 


### PR DESCRIPTION
For whatever reason, these lines have been commented and uncommented several times. I believe it is correct to NOT call scale, because it appears to have been set somewhere else already. An easy way to observe this is to simply change the SVGViewer sample to call `svgDoc.Draw(width, height)` and measure the output. It is clear that the scaling happens twice, changing the width and height creates a non-linear scaling response.

Here you can see the original response to calling Draw(64, 64)
![before](https://cloud.githubusercontent.com/assets/9901978/24423002/271b90d8-13c1-11e7-9a9a-fb4dea2a6379.png)

And here is the response with the pull request
![after](https://cloud.githubusercontent.com/assets/9901978/24423005/290ebb22-13c1-11e7-8b3f-c0ce05e7b579.png)
