### PR TITLE
Removed Default Parameters to restore full .NET 3.5 support. Fix scaling

### DIFF
--- a/Source/DataTypes/SvgUnit.cs
+++ b/Source/DataTypes/SvgUnit.cs
@@ -181,7 +181,7 @@ namespace Svg
         {
             if (owner == null) return null;
             var visual = owner.Parents.OfType<SvgVisualElement>().FirstOrDefault();
-            return visual?.GetFont(renderer);
+            return visual == null ? null : visual.GetFont(renderer);
         }
 
         /// <summary>

--- a/Source/External/ExCSS/IToString.cs
+++ b/Source/External/ExCSS/IToString.cs
@@ -2,6 +2,6 @@
 {
     public interface IToString
     {
-        string ToString(bool friendlyFormat, int indentation = 0);
+        string ToString(bool friendlyFormat, int indentation);
     }
 }

--- a/Source/External/ExCSS/Model/MediaTypeList.cs
+++ b/Source/External/ExCSS/Model/MediaTypeList.cs
@@ -75,10 +75,10 @@ namespace ExCSS
 
         public override string ToString()
         {
-            return ToString(false);
+            return ToString(false, 0);
         }
 
-        public string ToString(bool friendlyFormat, int indentation = 0)
+        public string ToString(bool friendlyFormat, int indentation)
         {
             return friendlyFormat
                 ? string.Join(", ", _media.ToArray())

--- a/Source/External/ExCSS/Model/Rules/CharacterSetRule.cs
+++ b/Source/External/ExCSS/Model/Rules/CharacterSetRule.cs
@@ -11,13 +11,11 @@ namespace ExCSS
         }
 
         public string Encoding { get; internal set; }
-
         public override string ToString()
         {
-            return ToString(false);
+            return ToString(false,0);
         }
-
-        public override string ToString(bool friendlyFormat, int indentation = 0)
+        public override string ToString(bool friendlyFormat, int indentation)
         {
             return string.Format("@charset '{0}';", Encoding).NewLineIndent(friendlyFormat, indentation);
         }

--- a/Source/External/ExCSS/Model/Rules/DocumentRule.cs
+++ b/Source/External/ExCSS/Model/Rules/DocumentRule.cs
@@ -69,10 +69,10 @@ namespace ExCSS
 
         public override string ToString()
         {
-            return ToString(false);
+            return ToString(false, 0);
         }
 
-        public override string ToString(bool friendlyFormat, int indentation = 0)
+        public override string ToString(bool friendlyFormat, int indentation)
         {
             return "@document " + ConditionText + " {" + 
                 RuleSets + 

--- a/Source/External/ExCSS/Model/Rules/FontFaceRule.cs
+++ b/Source/External/ExCSS/Model/Rules/FontFaceRule.cs
@@ -75,10 +75,10 @@ namespace ExCSS
 
         public override string ToString()
         {
-            return ToString(false);
+            return ToString(false, 0);
         }
 
-        public override string ToString(bool friendlyFormat, int indentation = 0)
+        public override string ToString(bool friendlyFormat, int indentation)
         {
             return "@font-face{".NewLineIndent(friendlyFormat, indentation) +
                 _declarations.ToString(friendlyFormat, indentation) +

--- a/Source/External/ExCSS/Model/Rules/GenericRule.cs
+++ b/Source/External/ExCSS/Model/Rules/GenericRule.cs
@@ -20,10 +20,9 @@ namespace ExCSS
 
         public override string ToString()
         {
-            return ToString(false);
+            return this.ToString(false, 0);
         }
-
-        public override string ToString(bool friendlyFormat, int indentation = 0)
+        public override string ToString(bool friendlyFormat, int indentation)
         {
             if (_stopped)
             {

--- a/Source/External/ExCSS/Model/Rules/ImportRule.cs
+++ b/Source/External/ExCSS/Model/Rules/ImportRule.cs
@@ -28,10 +28,10 @@ namespace ExCSS
 
         public override string ToString()
         {
-            return ToString(false);
+            return ToString(false,0);
         }
 
-        public override string ToString(bool friendlyFormat, int indentation = 0)
+        public override string ToString(bool friendlyFormat, int indentation)
         {
             return _media.Count > 0
                 ? string.Format("@import url({0}) {1};", _href, _media).NewLineIndent(friendlyFormat, indentation)

--- a/Source/External/ExCSS/Model/Rules/KeyframeRule.cs
+++ b/Source/External/ExCSS/Model/Rules/KeyframeRule.cs
@@ -24,10 +24,10 @@ namespace ExCSS
 
         public override string ToString()
         {
-            return ToString(false);
+            return ToString(false,0);
         }
 
-        public override string ToString(bool friendlyFormat, int indentation = 0)
+        public override string ToString(bool friendlyFormat, int indentation)
         {
             return string.Empty.Indent(friendlyFormat, indentation) +
                 _value + 

--- a/Source/External/ExCSS/Model/Rules/KeyframesRule.cs
+++ b/Source/External/ExCSS/Model/Rules/KeyframesRule.cs
@@ -31,10 +31,10 @@ namespace ExCSS
 
         public override string ToString()
         {
-            return ToString(false);
+            return ToString(false,0);
         }
 
-        public override string ToString(bool friendlyFormat, int indentation = 0)
+        public override string ToString(bool friendlyFormat, int indentation)
         {
             var join = friendlyFormat ? "".NewLineIndent(true, indentation) : "";
 

--- a/Source/External/ExCSS/Model/Rules/MediaRule.cs
+++ b/Source/External/ExCSS/Model/Rules/MediaRule.cs
@@ -29,10 +29,10 @@ namespace ExCSS
 
         public override string ToString()
         {
-            return ToString(false);
+            return ToString(false,0);
         }
 
-        public override string ToString(bool friendlyFormat, int indentation = 0)
+        public override string ToString(bool friendlyFormat, int indentation)
         {
             var join = friendlyFormat ? "".NewLineIndent(true, indentation + 1) : "";
 

--- a/Source/External/ExCSS/Model/Rules/NamespaceRule.cs
+++ b/Source/External/ExCSS/Model/Rules/NamespaceRule.cs
@@ -17,10 +17,10 @@ namespace ExCSS
 
         public override string ToString()
         {
-            return ToString(false);
+            return ToString(false,0);
         }
 
-        public override string ToString(bool friendlyFormat, int indentation = 0)
+        public override string ToString(bool friendlyFormat, int indentation)
         {
             return string.IsNullOrEmpty(Prefix)
                  ? string.Format("@namespace '{0}';", Uri).NewLineIndent(friendlyFormat, indentation)

--- a/Source/External/ExCSS/Model/Rules/PageRule.cs
+++ b/Source/External/ExCSS/Model/Rules/PageRule.cs
@@ -39,10 +39,10 @@ namespace ExCSS
 
         public override string ToString()
         {
-            return ToString(false);
+            return ToString(false, 0);
         }
 
-        public override string ToString(bool friendlyFormat, int indentation = 0)
+        public override string ToString(bool friendlyFormat, int indentation)
         {
             var pseudo = string.IsNullOrEmpty(_selectorText)
                              ? ""

--- a/Source/External/ExCSS/Model/Rules/RuleSet.cs
+++ b/Source/External/ExCSS/Model/Rules/RuleSet.cs
@@ -10,7 +10,6 @@ namespace ExCSS
         }
 
         public RuleType RuleType { get; set; }
-
-        public abstract string ToString(bool friendlyFormat, int indentation = 0);
+        public abstract string ToString(bool friendlyFormat, int indentation);
     }
 }

--- a/Source/External/ExCSS/Model/Rules/StyleDeclaration.cs
+++ b/Source/External/ExCSS/Model/Rules/StyleDeclaration.cs
@@ -75,10 +75,10 @@ namespace ExCSS
 
         public override string ToString()
         {
-            return ToString(false);
+            return ToString(false,0);
         }
 
-        public string ToString(bool friendlyFormat, int indentation = 0)
+        public string ToString(bool friendlyFormat, int indentation)
         { 
             var builder = new StringBuilder();
 

--- a/Source/External/ExCSS/Model/Rules/StyleRule.cs
+++ b/Source/External/ExCSS/Model/Rules/StyleRule.cs
@@ -47,10 +47,10 @@ namespace ExCSS
 
         public override string ToString()
         {
-            return ToString(false);
+            return ToString(false,0);
         }
 
-        public override string ToString(bool friendlyFormat, int indentation = 0)
+        public override string ToString(bool friendlyFormat, int indentation)
         {
             return _value.NewLineIndent(friendlyFormat, indentation) +
                 "{" +

--- a/Source/External/ExCSS/Model/Rules/SupportsRule.cs
+++ b/Source/External/ExCSS/Model/Rules/SupportsRule.cs
@@ -24,10 +24,10 @@ namespace ExCSS
 
         public override string ToString()
         {
-            return ToString(false);
+            return ToString(false,0);
         }
 
-        public override string ToString(bool friendlyFormat, int indentation = 0)
+        public override string ToString(bool friendlyFormat, int indentation)
         {
             var join = friendlyFormat ? "".NewLineIndent(true, indentation + 1) : "";
 

--- a/Source/External/ExCSS/Model/Selector/AggregateSelectorList.cs
+++ b/Source/External/ExCSS/Model/Selector/AggregateSelectorList.cs
@@ -17,8 +17,7 @@ namespace ExCSS
             
             Delimiter = delimiter;
         }
-
-        public override string ToString(bool friendlyFormat, int indentation = 0)
+        public override string ToString(bool friendlyFormat, int indentation)
         {
             var builder = new StringBuilder();
 

--- a/Source/External/ExCSS/Model/Selector/BaseSelector.cs
+++ b/Source/External/ExCSS/Model/Selector/BaseSelector.cs
@@ -6,10 +6,10 @@ namespace ExCSS
     {
         public sealed override string ToString()
         {
-            return ToString(false);
+            return ToString(false,0);
         }
 
-        public abstract string ToString(bool friendlyFormat, int indentation = 0);
+        public abstract string ToString(bool friendlyFormat, int indentation);
     }
 }
 

--- a/Source/External/ExCSS/Model/Selector/ComplexSelector.cs
+++ b/Source/External/ExCSS/Model/Selector/ComplexSelector.cs
@@ -41,7 +41,7 @@ namespace ExCSS
             return ((IEnumerable)_selectors).GetEnumerator();
         }
 
-        public override string ToString(bool friendlyFormat, int indentation = 0)
+        public override string ToString(bool friendlyFormat, int indentation)
         {
             var builder = new StringBuilder();
 

--- a/Source/External/ExCSS/Model/Selector/FirstChildSelector.cs
+++ b/Source/External/ExCSS/Model/Selector/FirstChildSelector.cs
@@ -12,8 +12,7 @@ namespace ExCSS
         {
             get { return _instance ?? (_instance = new FirstChildSelector()); }
         }
-
-        public override string ToString(bool friendlyFormat, int indentation = 0)
+        public override string ToString(bool friendlyFormat, int indentation)
         {
             return ":" + PseudoSelectorPrefix.PseudoFirstchild;
         }

--- a/Source/External/ExCSS/Model/Selector/LastChildSelector.cs
+++ b/Source/External/ExCSS/Model/Selector/LastChildSelector.cs
@@ -13,7 +13,7 @@ namespace ExCSS
             get { return _instance ?? (_instance = new LastChildSelector()); }
         }
 
-        public override string ToString(bool friendlyFormat, int indentation = 0)
+        public override string ToString(bool friendlyFormat, int indentation)
         {
             return ":" + PseudoSelectorPrefix.PseudoLastchild;
         }

--- a/Source/External/ExCSS/Model/Selector/MultipleSelectorList.cs
+++ b/Source/External/ExCSS/Model/Selector/MultipleSelectorList.cs
@@ -19,7 +19,7 @@ namespace ExCSS
 
         internal bool IsInvalid { get; set; }
 
-        public override string ToString(bool friendlyFormat, int indentation = 0)
+        public override string ToString(bool friendlyFormat, int indentation)
         {
             var builder = new StringBuilder();
 

--- a/Source/External/ExCSS/Model/Selector/NthChildSelector.cs
+++ b/Source/External/ExCSS/Model/Selector/NthChildSelector.cs
@@ -19,6 +19,6 @@ namespace ExCSS
                 : string.Format(":{0}({1})", functionName, FunctionText);
         }
 
-        public abstract override string ToString(bool friendlyFormat, int indentation = 0);
+        public abstract override string ToString(bool friendlyFormat, int indentation);
     }
 }

--- a/Source/External/ExCSS/Model/Selector/NthFirstChildSelector.cs
+++ b/Source/External/ExCSS/Model/Selector/NthFirstChildSelector.cs
@@ -4,7 +4,7 @@ namespace ExCSS
 {
     internal sealed class NthFirstChildSelector : NthChildSelector, IToString
     {
-        public override string ToString(bool friendlyFormat, int indentation = 0)
+        public override string ToString(bool friendlyFormat, int indentation)
         {
             return FormatSelector(PseudoSelectorPrefix.PseudoFunctionNthchild);
         }

--- a/Source/External/ExCSS/Model/Selector/NthLastChildSelector.cs
+++ b/Source/External/ExCSS/Model/Selector/NthLastChildSelector.cs
@@ -5,7 +5,7 @@ namespace ExCSS
 {
     internal sealed class NthLastChildSelector : NthChildSelector, IToString
     {
-        public override string ToString(bool friendlyFormat, int indentation = 0)
+        public override string ToString(bool friendlyFormat, int indentation)
         {
             return FormatSelector(PseudoSelectorPrefix.PseudoFunctionNthlastchild);
         }

--- a/Source/External/ExCSS/Model/Selector/NthLastOfTypeSelector.cs
+++ b/Source/External/ExCSS/Model/Selector/NthLastOfTypeSelector.cs
@@ -4,7 +4,7 @@ namespace ExCSS
 {
     internal sealed class NthLastOfTypeSelector : NthChildSelector, IToString
     {
-        public override string ToString(bool friendlyFormat, int indentation = 0)
+        public override string ToString(bool friendlyFormat, int indentation)
         {
             return FormatSelector(PseudoSelectorPrefix.PseudoFunctionNthLastOfType);
         }

--- a/Source/External/ExCSS/Model/Selector/NthOfTypeSelector.cs
+++ b/Source/External/ExCSS/Model/Selector/NthOfTypeSelector.cs
@@ -4,7 +4,7 @@ namespace ExCSS
 {
     internal sealed class NthOfTypeSelector : NthChildSelector, IToString
     {
-        public override string ToString(bool friendlyFormat, int indentation = 0)
+        public override string ToString(bool friendlyFormat, int indentation)
         {
             return FormatSelector(PseudoSelectorPrefix.PseudoFunctionNthOfType);
         }

--- a/Source/External/ExCSS/Model/Selector/SelectorList.cs
+++ b/Source/External/ExCSS/Model/Selector/SelectorList.cs
@@ -52,6 +52,6 @@ namespace ExCSS
             return ((IEnumerable)Selectors).GetEnumerator();
         }
 
-        public override abstract string ToString(bool friendlyFormat, int indentation = 0);
+        public override abstract string ToString(bool friendlyFormat, int indentation);
     }
 }

--- a/Source/External/ExCSS/Model/Selector/SimpleSelector.cs
+++ b/Source/External/ExCSS/Model/Selector/SimpleSelector.cs
@@ -118,7 +118,7 @@ namespace ExCSS
             return "'" + value + "'";
         }
 
-        public override string ToString(bool friendlyFormat, int indentation = 0)
+        public override string ToString(bool friendlyFormat, int indentation)
         {
             return _code;
         }

--- a/Source/External/ExCSS/Model/TextBlocks/BracketBlock.cs
+++ b/Source/External/ExCSS/Model/TextBlocks/BracketBlock.cs
@@ -91,10 +91,10 @@ namespace ExCSS.Model.TextBlocks
 
         public override string ToString()
         {
-            return ToString(false);
+            return ToString(false, 0);
         }
 
-        public string ToString(bool friendlyFormat, int indentation = 0)
+        public string ToString(bool friendlyFormat, int indentation)
         {
             switch (GrammarSegment)
             {

--- a/Source/External/ExCSS/Model/TextBlocks/StringBlock.cs
+++ b/Source/External/ExCSS/Model/TextBlocks/StringBlock.cs
@@ -8,12 +8,20 @@ namespace ExCSS.Model.TextBlocks
             GrammarSegment = type;
         }
 
-        internal static StringBlock Plain(string data, bool bad = false)
+        
+        internal static StringBlock Plain(string data)
+        {
+            return Plain(data,false);
+        }
+        internal static StringBlock Plain(string data, bool bad)
         {
             return new StringBlock(GrammarSegment.String) { Value = data, IsBad = bad };
         }
-
-        internal static StringBlock Url(string data, bool bad = false)
+        internal static StringBlock Url(string data)
+        {
+            return Url(data,false);
+        }
+        internal static StringBlock Url(string data, bool bad)
         {
             return new StringBlock(GrammarSegment.Url) { Value = data, IsBad = bad };
         }

--- a/Source/External/ExCSS/Model/Values/HtmlColor.cs
+++ b/Source/External/ExCSS/Model/Values/HtmlColor.cs
@@ -181,23 +181,27 @@ namespace ExCSS
 
         public override string ToString()
         {
-            return ToString(false);
+            return ToString(false,0);
         }
 
-        public string ToString(bool friendlyFormat, int indentation = 0)
+        public string ToString(bool friendlyFormat, int indentation)
         {
             return ToCss().Indent(friendlyFormat, indentation);
         }
 
-        public string ToString(bool forceLong, bool friendlyFormat, int indentation = 0)
+        public string ToString(bool forceLong, bool friendlyFormat, int indentation)
         {
             return ToCss(forceLong).Indent(friendlyFormat, indentation);
         }
 
+        string ToCss()
+        {
+            return ToCss(false);
+        }
         /// <summary>
         /// Return the shortest form possible
         /// </summary>
-        string ToCss(bool forceLong = false)
+        string ToCss(bool forceLong)
         {
             if (A == 255 && !forceLong && ((R >> 4) == (R & 0x0F)) && ((G >> 4) == (G & 0x0F)) && ((B >> 4) == (B & 0x0F)))
                 return "#" + R.ToHexChar() + G.ToHexChar() + B.ToHexChar();

--- a/Source/External/ExCSS/Model/Values/Property.cs
+++ b/Source/External/ExCSS/Model/Values/Property.cs
@@ -29,10 +29,10 @@ namespace ExCSS
 
         public override string ToString()
         {
-            return ToString(false);
+            return ToString(false,0);
         }
 
-        public string ToString(bool friendlyFormat, int indentation = 0)
+        public string ToString(bool friendlyFormat, int indentation)
         { 
             var value = Name + ":" + _term;
 

--- a/Source/External/ExCSS/Parser.cs
+++ b/Source/External/ExCSS/Parser.cs
@@ -104,16 +104,18 @@ namespace ExCSS
                 ? styleSheet.Rules[0] 
                 : null;
         }
-
-        internal static StyleDeclaration ParseDeclarations(string declarations, bool quirksMode = false)
+        
+        internal static StyleDeclaration ParseDeclarations(string declarations) { return ParseDeclarations(declarations,false);}
+        internal static StyleDeclaration ParseDeclarations(string declarations, bool quirksMode)
         {
             var decl = new StyleDeclaration();
             AppendDeclarations(decl, declarations, quirksMode);
 
             return decl;
         }
-
-        internal static void AppendDeclarations(StyleDeclaration list, string css, bool quirksMode = false)
+        
+        internal static void AppendDeclarations(StyleDeclaration list, string css) { AppendDeclarations(list, css,false);}
+        internal static void AppendDeclarations(StyleDeclaration list, string css, bool quirksMode)
         {
             var parser = new Parser();//(new StyleSheet(), new StylesheetReader(declarations))
            

--- a/Source/External/ExCSS/StyleSheet.cs
+++ b/Source/External/ExCSS/StyleSheet.cs
@@ -128,10 +128,10 @@ namespace ExCSS
 
         public override string ToString()
         {
-            return ToString(false);
+            return ToString(false,0);
         }
 
-        public string ToString(bool friendlyFormat, int indentation = 0)
+        public string ToString(bool friendlyFormat, int indentation)
         {
             var builder = new StringBuilder();
 

--- a/Source/External/Extensions.cs
+++ b/Source/External/Extensions.cs
@@ -1,0 +1,10 @@
+﻿namespace ExCSS
+{
+    static class Extensions
+    {
+        public static string ToString(this IToString source, bool friendlyFormat)
+        {
+            return source.ToString(friendlyFormat, 0);
+        }
+    }
+}

--- a/Source/Painting/SvgColourServer.cs
+++ b/Source/Painting/SvgColourServer.cs
@@ -35,7 +35,8 @@ namespace Svg
             set { this._colour = value; }
         }
 
-        public override Brush GetBrush(SvgVisualElement styleOwner, ISvgRenderer renderer, float opacity, bool forStroke = false)
+        
+        public override Brush GetBrush(SvgVisualElement styleOwner, ISvgRenderer renderer, float opacity, bool forStroke)
         {
             //is none?
             if (this == SvgPaintServer.None) return new SolidBrush(System.Drawing.Color.Transparent);

--- a/Source/Painting/SvgDeferredPaintServer.cs
+++ b/Source/Painting/SvgDeferredPaintServer.cs
@@ -45,7 +45,7 @@ namespace Svg
             }
         }
 
-        public override Brush GetBrush(SvgVisualElement styleOwner, ISvgRenderer renderer, float opacity, bool forStroke = false)
+        public override Brush GetBrush(SvgVisualElement styleOwner, ISvgRenderer renderer, float opacity, bool forStroke)
         {
             EnsureServer(styleOwner);
             return _concreteServer.GetBrush(styleOwner, renderer, opacity, forStroke);

--- a/Source/Painting/SvgFallbackPaintServer .cs
+++ b/Source/Painting/SvgFallbackPaintServer .cs
@@ -21,7 +21,7 @@ namespace Svg
             _primary = primary;
         }
 
-        public override Brush GetBrush(SvgVisualElement styleOwner, ISvgRenderer renderer, float opacity, bool forStroke = false)
+        public override Brush GetBrush(SvgVisualElement styleOwner, ISvgRenderer renderer, float opacity, bool forStroke)
         {
             try
             {

--- a/Source/Painting/SvgLinearGradientServer.cs
+++ b/Source/Painting/SvgLinearGradientServer.cs
@@ -79,7 +79,7 @@ namespace Svg
             Y2 = new SvgUnit(SvgUnitType.Percentage, 0F);
         }
 
-        public override Brush GetBrush(SvgVisualElement renderingElement, ISvgRenderer renderer, float opacity, bool forStroke = false)
+        public override Brush GetBrush(SvgVisualElement renderingElement, ISvgRenderer renderer, float opacity, bool forStroke)
         {
             LoadStops(renderingElement);
 

--- a/Source/Painting/SvgPaintServer.cs
+++ b/Source/Painting/SvgPaintServer.cs
@@ -41,7 +41,7 @@ namespace Svg
         /// </summary>
         /// <param name="styleOwner">The owner <see cref="SvgVisualElement"/>.</param>
         /// <param name="opacity">The opacity of the brush.</param>
-        public abstract Brush GetBrush(SvgVisualElement styleOwner, ISvgRenderer renderer, float opacity, bool forStroke = false);
+        public abstract Brush GetBrush(SvgVisualElement styleOwner, ISvgRenderer renderer, float opacity, bool forStroke);
 
         /// <summary>
         /// Returns a <see cref="T:System.String"/> that represents the current <see cref="T:System.Object"/>.

--- a/Source/Painting/SvgPatternServer.cs
+++ b/Source/Painting/SvgPatternServer.cs
@@ -167,12 +167,13 @@ namespace Svg
                     orig);
         }
 
+        
         /// <summary>
         /// Gets a <see cref="Brush"/> representing the current paint server.
         /// </summary>
         /// <param name="renderingElement">The owner <see cref="SvgVisualElement"/>.</param>
         /// <param name="opacity">The opacity of the brush.</param>
-        public override Brush GetBrush(SvgVisualElement renderingElement, ISvgRenderer renderer, float opacity, bool forStroke = false)
+        public override Brush GetBrush(SvgVisualElement renderingElement, ISvgRenderer renderer, float opacity, bool forStroke)
         {
             var chain = new List<SvgPatternServer>();
             var curr = this;

--- a/Source/Painting/SvgRadialGradientServer.cs
+++ b/Source/Painting/SvgRadialGradientServer.cs
@@ -105,7 +105,7 @@ namespace Svg
                     orig);
         }
 
-        public override Brush GetBrush(SvgVisualElement renderingElement, ISvgRenderer renderer, float opacity, bool forStroke = false)
+        public override Brush GetBrush(SvgVisualElement renderingElement, ISvgRenderer renderer, float opacity, bool forStroke)
         {
             LoadStops(renderingElement);
 
@@ -140,7 +140,7 @@ namespace Svg
 
                 // Calculate any required scaling
                 var scaleBounds = RectangleF.Inflate(renderingElement.Bounds, renderingElement.StrokeWidth, renderingElement.StrokeWidth);
-								var scale = CalcScale(scaleBounds, path);
+								var scale = CalcScale(scaleBounds, path,null);
 
                 // Not ideal, but this makes sure that the rest of the shape gets properly filled or drawn
                 if (scale > 1.0f && SpreadMethod == SvgGradientSpreadMethod.Pad)
@@ -156,7 +156,7 @@ namespace Svg
                         {
                             var newClip = origClip.Clone();
                             newClip.Exclude(path);
-                            renderer.SetClip(newClip);
+                            renderer.SetClip(newClip, CombineMode.Replace);
 
                             var renderPath = (GraphicsPath)renderingElement.Path(renderer);
                             if (forStroke)
@@ -215,7 +215,7 @@ namespace Svg
         /// This method continually transforms the rectangle (fewer points) until it is contained by the path
         /// and returns the result of the search.  The scale factor is set to a constant 95%
         /// </remarks>
-        private float CalcScale(RectangleF bounds, GraphicsPath path, Graphics graphics = null)
+        private float CalcScale(RectangleF bounds, GraphicsPath path, Graphics graphics)
         {
             var points = new PointF[] {
                 new PointF(bounds.Left, bounds.Top), 

--- a/Source/Rendering/ISvgRenderer.cs
+++ b/Source/Rendering/ISvgRenderer.cs
@@ -15,12 +15,12 @@ namespace Svg
         ISvgBoundable GetBoundable();
         Region GetClip();
         ISvgBoundable PopBoundable();
-        void RotateTransform(float fAngle, MatrixOrder order = MatrixOrder.Append);
-        void ScaleTransform(float sx, float sy, MatrixOrder order = MatrixOrder.Append);
+        void RotateTransform(float fAngle, MatrixOrder order);
+        void ScaleTransform(float sx, float sy, MatrixOrder order);
         void SetBoundable(ISvgBoundable boundable);
-        void SetClip(Region region, CombineMode combineMode = CombineMode.Replace);
+        void SetClip(Region region, CombineMode combineMode);
         SmoothingMode SmoothingMode { get; set; }
         Matrix Transform { get; set; }
-        void TranslateTransform(float dx, float dy, MatrixOrder order = MatrixOrder.Append);
+        void TranslateTransform(float dx, float dy, MatrixOrder order);
     }
 }

--- a/Source/Rendering/SvgRenderer.cs
+++ b/Source/Rendering/SvgRenderer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.Drawing;
 using System.Drawing.Drawing2D;
@@ -62,19 +61,19 @@ namespace Svg
         {
             return this._innerGraphics.Clip;
         }
-        public void RotateTransform(float fAngle, MatrixOrder order = MatrixOrder.Append)
+        public void RotateTransform(float fAngle, MatrixOrder order)
         {
             this._innerGraphics.RotateTransform(fAngle, order);
         }
-        public void ScaleTransform(float sx, float sy, MatrixOrder order = MatrixOrder.Append)
+        public void ScaleTransform(float sx, float sy, MatrixOrder order)
         {
             this._innerGraphics.ScaleTransform(sx, sy, order);
         }
-        public void SetClip(Region region, CombineMode combineMode = CombineMode.Replace)
+        public void SetClip(Region region, CombineMode combineMode)
         {
             this._innerGraphics.SetClip(region, combineMode);
         }
-        public void TranslateTransform(float dx, float dy, MatrixOrder order = MatrixOrder.Append)
+        public void TranslateTransform(float dx, float dy, MatrixOrder order)
         {
             this._innerGraphics.TranslateTransform(dx, dy, order);
         }

--- a/Source/Svg.csproj
+++ b/Source/Svg.csproj
@@ -83,6 +83,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Core">
+      <RequiredTargetFramework>3.5</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Web" />
     <Reference Include="System.Xml" />
@@ -110,6 +114,7 @@
     <Compile Include="Document Structure\SvgSymbol.cs" />
     <Compile Include="Exceptions\SvgMemoryException.cs" />
     <Compile Include="ExtensionMethods\UriExtensions.cs" />
+    <Compile Include="External\Extensions.cs" />
     <Compile Include="Filter Effects\ImageBuffer.cs" />
     <Compile Include="Painting\GenericBoundable.cs" />
     <Compile Include="Painting\SvgFallbackPaintServer .cs" />
@@ -249,7 +254,7 @@
     <Compile Include="NonSvgElement.cs" />
     <Compile Include="SvgUnknownElement.cs" />
     <Compile Include="SvgElementAttribute.cs" />
-    <Compile Include="SvgExtentions.cs" />
+    <Compile Include="SvgExtensions.cs" />
     <Compile Include="Rendering\SvgRenderer.cs" />
     <Compile Include="Painting\SvgColourConverter.cs" />
     <Compile Include="Painting\SvgGradientSpreadMethod.cs" />
@@ -352,12 +357,12 @@
     <EmbeddedResource Include="Resources\svg11.dtd" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Web\Resources\" />
-  </ItemGroup>
-  <ItemGroup>
     <None Include="Basic Shapes\DOM.cd" />
     <None Include="Svg.nuspec" />
     <None Include="svgkey.snk" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Web\Resources\" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Source/Svg.csproj
+++ b/Source/Svg.csproj
@@ -254,7 +254,7 @@
     <Compile Include="NonSvgElement.cs" />
     <Compile Include="SvgUnknownElement.cs" />
     <Compile Include="SvgElementAttribute.cs" />
-    <Compile Include="SvgExtensions.cs" />
+    <Compile Include="SvgExtentions.cs" />
     <Compile Include="Rendering\SvgRenderer.cs" />
     <Compile Include="Painting\SvgColourConverter.cs" />
     <Compile Include="Painting\SvgGradientSpreadMethod.cs" />

--- a/Source/SvgDocument.cs
+++ b/Source/SvgDocument.cs
@@ -568,7 +568,15 @@ namespace Svg
             }
         }
 
-        public void Write(Stream stream, bool useBom = true)
+        public void Write(string path)
+        {
+            this.Write(path, false);
+        }
+        public void Write(Stream stream)
+        {
+            this.Write(stream, false);
+        }
+        public void Write(Stream stream, bool useBom)
         {
 
             var xmlWriter = new XmlTextWriter(stream, useBom ? Encoding.UTF8 : new System.Text.UTF8Encoding(false));
@@ -584,7 +592,7 @@ namespace Svg
             xmlWriter.Flush();
         }
 
-        public void Write(string path, bool useBom = true)
+        public void Write(string path, bool useBom)
         {
             using (var fs = new FileStream(path, FileMode.Create, FileAccess.Write))
             {

--- a/Source/SvgElement.cs
+++ b/Source/SvgElement.cs
@@ -372,7 +372,7 @@ namespace Svg
             get { return this.Attributes.GetAttribute<string>("id"); }
             set
             {
-                SetAndForceUniqueID(value, false);
+                SetAndForceUniqueID(value, false,null);
             }
         }
 
@@ -387,7 +387,7 @@ namespace Svg
             set { this.Attributes["space"] = value; }
         }
 
-        public void SetAndForceUniqueID(string value, bool autoForceUniqueID = true, Action<SvgElement, string, string> logElementOldIDNewID = null)
+        public void SetAndForceUniqueID(string value, bool autoForceUniqueID, Action<SvgElement, string, string> logElementOldIDNewID)
         {
             // Don't do anything if it hasn't changed
             if (string.Compare(this.ID, value) == 0)

--- a/Source/SvgElementCollection.cs
+++ b/Source/SvgElementCollection.cs
@@ -61,7 +61,7 @@ namespace Svg
         	 System.Diagnostics.Debug.WriteLine("ID of SVG element " + elem.ToString() + " changed from " + oldId + " to " + newID);
         }
 
-        public void InsertAndForceUniqueID(int index, SvgElement item, bool autoForceUniqueID = true, bool autoFixChildrenID = true, Action<SvgElement, string, string> logElementOldIDNewID = null)
+        public void InsertAndForceUniqueID(int index, SvgElement item, bool autoForceUniqueID, bool autoFixChildrenID, Action<SvgElement, string, string> logElementOldIDNewID)
         {
             AddToIdManager(item, this._elements[index], autoForceUniqueID, autoFixChildrenID, logElementOldIDNewID);
             this._elements.Insert(index, item);
@@ -89,14 +89,14 @@ namespace Svg
             this.AddAndForceUniqueID(item, true, true, LogIDChange);
         }
 
-        public void AddAndForceUniqueID(SvgElement item, bool autoForceUniqueID = true, bool autoFixChildrenID = true, Action<SvgElement, string, string> logElementOldIDNewID = null)
+        public void AddAndForceUniqueID(SvgElement item, bool autoForceUniqueID, bool autoFixChildrenID, Action<SvgElement, string, string> logElementOldIDNewID)
         {
             AddToIdManager(item, null, autoForceUniqueID, autoFixChildrenID, logElementOldIDNewID);
             this._elements.Add(item);
             item._parent.OnElementAdded(item, this.Count - 1);
         }
 
-        private void AddToIdManager(SvgElement item, SvgElement sibling, bool autoForceUniqueID = true, bool autoFixChildrenID = true, Action<SvgElement, string, string> logElementOldIDNewID = null)
+        private void AddToIdManager(SvgElement item, SvgElement sibling, bool autoForceUniqueID, bool autoFixChildrenID, Action<SvgElement, string, string> logElementOldIDNewID)
         {
             if (!this._mock)
             {

--- a/Source/SvgElementIdManager.cs
+++ b/Source/SvgElementIdManager.cs
@@ -74,7 +74,7 @@ namespace Svg
         /// <param name="element">The <see cref="SvgElement"/> to be managed.</param>
         public virtual void Add(SvgElement element)
         {
-            AddAndForceUniqueID(element, null, false);
+            AddAndForceUniqueID(element, null, false, null);
         }
 
         /// <summary>
@@ -85,7 +85,7 @@ namespace Svg
         /// <param name="autoForceUniqueID">Pass true here, if you want the ID to be fixed</param>
         /// <param name="logElementOldIDNewID">If not null, the action is called before the id is fixed</param>
         /// <returns>true, if ID was altered</returns>
-        public virtual bool AddAndForceUniqueID(SvgElement element, SvgElement sibling, bool autoForceUniqueID = true, Action<SvgElement, string, string> logElementOldIDNewID = null)
+        public virtual bool AddAndForceUniqueID(SvgElement element, SvgElement sibling, bool autoForceUniqueID, Action<SvgElement, string, string> logElementOldIDNewID)
         {
             var result = false;
             if (!string.IsNullOrEmpty(element.ID))
@@ -128,7 +128,7 @@ namespace Svg
         /// <para>The ID cannot start with a digit.</para>
         /// <para>An element with the same ID already exists within the containing <see cref="SvgDocument"/>.</para>
         /// </exception>
-        public string EnsureValidId(string id, bool autoForceUniqueID = false)
+        public string EnsureValidId(string id, bool autoForceUniqueID)
         {
 
             if (string.IsNullOrEmpty(id))

--- a/Source/SvgExtentions.cs
+++ b/Source/SvgExtentions.cs
@@ -15,6 +15,24 @@ namespace Svg
     /// </summary>
     public static class SvgExtentions
     {
+        public static Brush GetBrush(this SvgPaintServer source, SvgVisualElement styleOwner, ISvgRenderer renderer, float opacity)
+        {
+            return source.GetBrush(styleOwner, renderer, opacity, false);
+        }
+
+        public static void SetClip(this ISvgRenderer source,Region region)
+        {
+            source.SetClip(region, System.Drawing.Drawing2D.CombineMode.Replace);
+        }
+        public static void ScaleTransform(this ISvgRenderer source, float dx, float dy)
+        {
+            source.ScaleTransform(dx, dy, System.Drawing.Drawing2D.MatrixOrder.Append);
+        }
+
+        public static void TranslateTransform(this ISvgRenderer source, float dx, float dy)
+        {
+            source.TranslateTransform(dx, dy, System.Drawing.Drawing2D.MatrixOrder.Append);
+        }
         public static void SetRectangle(this SvgRectangle r, RectangleF bounds)
         {
             r.X = bounds.X;


### PR DESCRIPTION
I filed an issue but no one responded so I took it upon myself to fix the problem.

I removed any default parameters used and replaced them with overloaded methods that call the functional version. For the interfaces where I couldn't write a method body I used added extension methods instead. 

The extension method class was misnamed so I fixed that too.

Once I got the code to compile I discovered that scaling did not work on a draw to bitmap and fixed that as well.