### PR TITLE
Add size option to Draw(Graphics) method

### DIFF
--- a/Source/SvgDocument.cs
+++ b/Source/SvgDocument.cs
@@ -422,8 +422,9 @@ namespace Svg
         /// Renders the <see cref="SvgDocument"/> to the specified <see cref="Graphics"/>.
         /// </summary>
         /// <param name="graphics">The <see cref="Graphics"/> to be rendered to.</param>
+        /// <param name="size">The <see cref="SizeF"/> to render the document.</param>
         /// <exception cref="ArgumentNullException">The <paramref name="graphics"/> parameter cannot be <c>null</c>.</exception>
-        public void Draw(Graphics graphics)
+        public void Draw(Graphics graphics, SizeF? size = null)
         {
             if (graphics == null)
             {
@@ -431,15 +432,22 @@ namespace Svg
             }
 
             var renderer = SvgRenderer.FromGraphics(graphics);
-            renderer.SetBoundable(this);
+            if (size.HasValue)
+            {
+                renderer.SetBoundable(new GenericBoundable(0, 0, size.Value.Width, size.Value.Height));
+            }
+            else
+            {
+                renderer.SetBoundable(this);
+            }
             this.Render(renderer);
         }
 
-	    /// <summary>
-	    /// Renders the <see cref="SvgDocument"/> and returns the image as a <see cref="Bitmap"/>.
-	    /// </summary>
-	    /// <returns>A <see cref="Bitmap"/> containing the rendered document.</returns>
-	    public virtual Bitmap Draw()
+        /// <summary>
+        /// Renders the <see cref="SvgDocument"/> and returns the image as a <see cref="Bitmap"/>.
+        /// </summary>
+        /// <returns>A <see cref="Bitmap"/> containing the rendered document.</returns>
+        public virtual Bitmap Draw()
 	    {
 		    //Trace.TraceInformation("Begin Render");
 

--- a/Source/SvgDocument.cs
+++ b/Source/SvgDocument.cs
@@ -422,7 +422,7 @@ namespace Svg
         /// Renders the <see cref="SvgDocument"/> to the specified <see cref="Graphics"/>.
         /// </summary>
         /// <param name="graphics">The <see cref="Graphics"/> to be rendered to.</param>
-        /// <param name="size">The <see cref="SizeF"/> to render the document.</param>
+        /// <param name="size">The <see cref="SizeF"/> to render the document. If <c>null</c> document is rendered at the default document size.</param>
         /// <exception cref="ArgumentNullException">The <paramref name="graphics"/> parameter cannot be <c>null</c>.</exception>
         public void Draw(Graphics graphics, SizeF? size = null)
         {

--- a/Source/SvgDocument.cs
+++ b/Source/SvgDocument.cs
@@ -443,11 +443,11 @@ namespace Svg
             this.Render(renderer);
         }
 
-        /// <summary>
-        /// Renders the <see cref="SvgDocument"/> and returns the image as a <see cref="Bitmap"/>.
-        /// </summary>
-        /// <returns>A <see cref="Bitmap"/> containing the rendered document.</returns>
-        public virtual Bitmap Draw()
+	    /// <summary>
+	    /// Renders the <see cref="SvgDocument"/> and returns the image as a <see cref="Bitmap"/>.
+	    /// </summary>
+	    /// <returns>A <see cref="Bitmap"/> containing the rendered document.</returns>
+	    public virtual Bitmap Draw()
 	    {
 		    //Trace.TraceInformation("Begin Render");
 


### PR DESCRIPTION
Sorry for all my misguided pull requests in the past. I finally upgraded from VS2008.

This is a simple feature I needed for printing in my application to render directly on a graphics object at a specified size. (Rendering directly on graphics is very important when printing to PDF as it is remains a vector image in the PDF).

I copied the sizing technique from the bitmap draw method and used the SetBoundable method of the renderer. 