### PR TITLE
Fixed bug causing all glyphs in an embedded SvgFont to be drawn.

### DIFF
--- a/Source/Text/SvgFont.cs
+++ b/Source/Text/SvgFont.cs
@@ -51,5 +51,8 @@ namespace Svg
         {
             return base.DeepCopy<SvgFont>();
         }
-    }
+
+        protected override void Render(ISvgRenderer renderer)
+        { }
+	}
 }


### PR DESCRIPTION
When embedding fonts in an .svg file the glyph paths are all rendered when the document is rendered. To avoid this an empty override of the Render method is added to the SvgFont class.