### PR TITLE
Compatibility with SVG generated by Highcharts in IE

### DIFF
--- a/Source/DataTypes/SvgTextTransformation.cs
+++ b/Source/DataTypes/SvgTextTransformation.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.ComponentModel;
+
+namespace Svg
+{
+    /// <summary>This property describes transformations that are added to the text of an element.</summary>
+    [TypeConverter(typeof(SvgTextTransformationConverter))]
+    [Flags]
+    public enum SvgTextTransformation
+    {
+        /// <summary>The value is inherited from the parent element.</summary>
+        Inherit = 0,
+
+        /// <summary>The text is not transformed.</summary>
+        None = 1,
+
+        /// <summary>First letter of each word of the text is converted to uppercase.</summary>
+        Capitalize = 2,
+
+        /// <summary>The text is converted to uppercase.</summary>
+        Uppercase = 4,
+
+        /// <summary>The text is converted to lowercase.</summary>
+        Lowercase = 8
+    }
+}

--- a/Source/External/ExCSS/Model/Values/TermList.cs
+++ b/Source/External/ExCSS/Model/Values/TermList.cs
@@ -119,5 +119,13 @@ namespace ExCSS
             Comma,
             Space
         }
+
+        internal void SetLastTerm(Term term)
+        {
+            if (Length == 0)
+                AddTerm(term);
+            else
+                _items[Length - 1] = term;
+        }
     }
 }

--- a/Source/External/ExCSS/Parser.cs
+++ b/Source/External/ExCSS/Parser.cs
@@ -131,18 +131,18 @@ namespace ExCSS
 
         private bool AddTerm(Term value)
         {
+            var added = true;
+
             if (_isFraction)
             {
                 if (_terms.Length > 0)
                 {
-                    value = new PrimitiveTerm(UnitType.Unknown, _terms[0] + "/" + value);
-                    _terms = new TermList();
+                    value = new PrimitiveTerm(UnitType.Unknown, _terms[_terms.Length - 1] + "/" + value);
                 }
-
+                _terms.SetLastTerm(value);
                 _isFraction = false;
             }
-
-            if (_functionBuffers.Count > 0)
+            else if (_functionBuffers.Count > 0)
             {
                 _functionBuffers.Peek().TermList.Add(value);
             }
@@ -156,10 +156,10 @@ namespace ExCSS
             }
             else
             {
-                return false;
+                added = false;
             }
 
-            return true;
+            return added;
         }
 
         private void FinalizeProperty()

--- a/Source/Painting/EnumConverters.cs
+++ b/Source/Painting/EnumConverters.cs
@@ -305,13 +305,16 @@ namespace Svg
         [CLSCompliant(false)]
         public static bool TryParse<TEnum>(string value, out TEnum result) where TEnum : struct, IConvertible
         {
-            var retValue = value == null ?
-                        false :
-                        Enum.IsDefined(typeof(TEnum), value);
-            result = retValue ?
-                        (TEnum)Enum.Parse(typeof(TEnum), value) :
-                        default(TEnum);
-            return retValue;
+            try
+            {
+                result = (TEnum)Enum.Parse(typeof(TEnum), value, true);
+                return true;
+            }
+            catch
+            {
+                result = default(TEnum);
+                return false;
+            }
         }
     }
 }

--- a/Source/Painting/EnumConverters.cs
+++ b/Source/Painting/EnumConverters.cs
@@ -300,6 +300,11 @@ namespace Svg
         }
     }
 
+    public sealed class SvgTextTransformationConverter : EnumBaseConverter<SvgTextTransformation>
+    {
+        public SvgTextTransformationConverter() : base(SvgTextTransformation.None) { }
+    }
+
     public static class Enums 
     {
         [CLSCompliant(false)]

--- a/Source/Svg.csproj
+++ b/Source/Svg.csproj
@@ -102,6 +102,7 @@
     <Compile Include="Clipping and Masking\SvgMask.cs" />
     <Compile Include="DataTypes\ISvgSupportsCoordinateUnits.cs" />
     <Compile Include="DataTypes\SvgPointCollection.cs" />
+    <Compile Include="DataTypes\SvgTextTransformation.cs" />
     <Compile Include="DataTypes\SvgTextDecoration.cs" />
     <Compile Include="DataTypes\SvgTextLengthAdjust.cs" />
     <Compile Include="DataTypes\SvgTextPathMethod.cs" />

--- a/Source/SvgElementFactory.cs
+++ b/Source/SvgElementFactory.cs
@@ -217,6 +217,7 @@ namespace Svg
                 case "text-anchor":
                 case "text-decoration":
                 case "text-rendering":
+                case "text-transform":
                 case "unicode-bidi":
                 case "visibility":
                 case "word-spacing":

--- a/Source/SvgElementStyle.cs
+++ b/Source/SvgElementStyle.cs
@@ -249,6 +249,16 @@ namespace Svg
             set { this.Attributes["font-weight"] = value; this.IsPathDirty = true; }
         }
 
+        /// <summary>
+        /// Refers to the text transformation.
+        /// </summary>
+        [SvgAttribute("text-transform", true)]
+        public virtual SvgTextTransformation TextTransformation
+        {
+            get { return (SvgTextTransformation)(this.Attributes["text-transform"] ?? SvgTextTransformation.Inherit); }
+            set { this.Attributes["text-transform"] = value; this.IsPathDirty = true; }
+        }
+
         private enum FontParseState
         {
             fontStyle,

--- a/Source/Text/SvgTextBase.cs
+++ b/Source/Text/SvgTextBase.cs
@@ -8,6 +8,7 @@ using System.Drawing.Drawing2D;
 using System.Drawing.Text;
 using Svg.DataTypes;
 using System.Linq;
+using System.Globalization;
 
 namespace Svg
 {
@@ -390,12 +391,13 @@ namespace Svg
         private static readonly Regex MultipleSpaces = new Regex(@" {2,}", RegexOptions.Compiled);
 
         /// <summary>
-        /// Prepare the text according to the whitespace handling rules.  <see href="http://www.w3.org/TR/SVG/text.html">SVG Spec</see>.
+        /// Prepare the text according to the whitespace handling rules and text transformations.  <see href="http://www.w3.org/TR/SVG/text.html">SVG Spec</see>.
         /// </summary>
         /// <param name="value">Text to be prepared</param>
         /// <returns>Prepared text</returns>
         protected string PrepareText(string value)
         {
+            value = ApplyTransformation(value);
             if (this.SpaceHandling == XmlSpaceHandling.preserve)
             {
                 return value.Replace('\t', ' ').Replace("\r\n", " ").Replace('\r', ' ').Replace('\n', ' ');
@@ -405,6 +407,23 @@ namespace Svg
                 var convValue = MultipleSpaces.Replace(value.Replace("\r", "").Replace("\n", "").Replace('\t', ' '), " ");
                 return convValue;
             }
+        }
+
+        private string ApplyTransformation(string value)
+        {
+            switch (this.TextTransformation)
+            {
+                case SvgTextTransformation.Capitalize:
+                    return value.ToUpper();
+
+                case SvgTextTransformation.Uppercase:
+                    return value.ToUpper();
+
+                case SvgTextTransformation.Lowercase:
+                    return CultureInfo.CurrentCulture.TextInfo.ToTitleCase(value);
+            }
+
+            return value;
         }
 
         [SvgAttribute("onchange")]


### PR DESCRIPTION
This pull request fixes the following problems in the library when it encounters snippets like

```
<text style="font: bold 15px/normal externalfont; text-transform: uppercase;">Text</text>
```

- font shorthand is parsed incorrectly;
- font weight and variant are not being mapped to the enumerations;
- text is not rendered uppercase.