### PR TITLE
Fix path parsing mistaking 'E' as a command instead of an exponent

### DIFF
--- a/Source/Paths/SvgPathBuilder.cs
+++ b/Source/Paths/SvgPathBuilder.cs
@@ -257,7 +257,7 @@ namespace Svg
             for (var i = 0; i < path.Length; i++)
             {
                 string command;
-                if (char.IsLetter(path[i]) && path[i] != 'e') //e is used in scientific notiation. but not svg path
+                if (char.IsLetter(path[i]) && path[i] != 'e' && path[i] != 'E') //e is used in scientific notiation. but not svg path
                 {
                     command = path.Substring(commandStart, i - commandStart).Trim();
                     commandStart = i;


### PR DESCRIPTION
We need to ignore uppercase 'E' (along with 'e') when splitting path string by command letters. The parser is mangling paths that use uppercase 'E' for exponents.

See grammar for path data: [https://www.w3.org/TR/SVG/paths.html#PathDataBNF](https://www.w3.org/TR/SVG/paths.html#PathDataBNF)

Repo:

`<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">`
`  <path fill="none" stroke="black" d="M10,10 L90,10 L90,90 L1E1,9E1 Z" />`
`</svg>`