### PR TITLE
Text positioning when printing - vertical graphics context resolution

### DIFF
--- a/Source/Text/GdiFontDefn.cs
+++ b/Source/Text/GdiFontDefn.cs
@@ -37,7 +37,7 @@ namespace Svg
             var ff = _font.FontFamily;
             float ascent = ff.GetCellAscent(_font.Style);
             float baselineOffset = _font.SizeInPoints / ff.GetEmHeight(_font.Style) * ascent;
-            return renderer.DpiY / 72f * baselineOffset;
+            return SvgDocument.PointsPerInch / 72f * baselineOffset;
         }
 
         public IList<RectangleF> MeasureCharacters(ISvgRenderer renderer, string text)

--- a/Source/Text/SvgFontDefn.cs
+++ b/Source/Text/SvgFontDefn.cs
@@ -39,7 +39,7 @@ namespace Svg
         {
             float ascent = _font.Descendants().OfType<SvgFontFace>().First().Ascent;
             float baselineOffset = this.SizeInPoints * (_emScale / _size) * ascent;
-            return renderer.DpiY / 72f * baselineOffset;
+            return SvgDocument.PointsPerInch / 72f * baselineOffset;
         }
 
         public IList<System.Drawing.RectangleF> MeasureCharacters(ISvgRenderer renderer, string text)


### PR DESCRIPTION
Hi,

Vertical graphics context resolution has been used in an inconsistent way. Only in Gdi/SvgFontDefn.cs/Ascent method, the DpiY property of graphics context is used to get the font baseline. This leads to wrong positioned text when printing.


Many thanks & Regards,
Matthias