### PR TITLE
For a "use" element, return the bounds of the referenced element

### DIFF
--- a/Source/Document Structure/SvgUse.cs
+++ b/Source/Document Structure/SvgUse.cs
@@ -64,7 +64,15 @@ namespace Svg
 
         public override System.Drawing.RectangleF Bounds
         {
-            get { return new System.Drawing.RectangleF(); }
+            get
+            {
+                var element = this.OwnerDocument.IdManager.GetElementById(this.ReferencedElement) as SvgVisualElement;
+                if (element != null)
+                {
+                    return element.Bounds;
+                }
+                return new System.Drawing.RectangleF();
+            }
         }
 
         protected override bool Renderable { get { return false; } }


### PR DESCRIPTION
- fixes TestPrivateFront unit test (threw exception because the image
  had zero size, as the only element is a "use" element)
- fixes #74

Found this while working on #375 to get the tests running.