### PR TITLE
Fix just Compiler Warning (level 3) CS0659.

### DIFF
--- a/Source/SvgAttributeAttribute.cs
+++ b/Source/SvgAttributeAttribute.cs
@@ -35,6 +35,11 @@ namespace Svg
             return Match(obj);
         }
 
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
+
         /// <summary>
         /// When overridden in a derived class, returns a value that indicates whether this instance equals a specified object.
         /// </summary>


### PR DESCRIPTION
`SVG\Source\SvgAttributeAttribute.cs(13,18,13,39): warning CS0659: 'SvgAttributeAttribute' overrides Object.Equals(object o) but does not override Object.GetHashCode()`

https://docs.microsoft.com/dotnet/csharp/misc/cs0659

ref. #365