### PR TITLE
Added "stroke-dashoffset" support

### DIFF
--- a/Source/Basic Shapes/SvgVisualElement.cs
+++ b/Source/Basic Shapes/SvgVisualElement.cs
@@ -254,6 +254,12 @@ namespace Svg
                                     /* divide by stroke width - GDI behaviour that I don't quite understand yet.*/
                                     pen.DashPattern = this.StrokeDashArray.ConvertAll(u => ((u.ToDeviceValue(renderer, UnitRenderingType.Other, this) <= 0) ? 1 : u.ToDeviceValue(renderer, UnitRenderingType.Other, this)) /
                                         ((strokeWidth <= 0) ? 1 : strokeWidth)).ToArray();
+
+                                    if (this.StrokeDashOffset != null && this.StrokeDashOffset.Value != 0)
+                                    {
+                                        pen.DashOffset = ((this.StrokeDashOffset.ToDeviceValue(renderer, UnitRenderingType.Other, this) <= 0) ? 1 : this.StrokeDashOffset.ToDeviceValue(renderer, UnitRenderingType.Other, this)) /
+                                            ((strokeWidth <= 0) ? 1 : strokeWidth);
+                                    }
                                 }
                                 switch (this.StrokeLineJoin)
                                 {

--- a/Tests/Svg.UnitTests/PassingTests.csv
+++ b/Tests/Svg.UnitTests/PassingTests.csv
@@ -49,6 +49,7 @@ painting-fill-03-t
 painting-fill-05-b
 painting-stroke-01-t
 painting-stroke-02-t
+painting-stroke-04-t
 painting-stroke-09-t
 painting-stroke-10-t
 paths-data-01-t

--- a/Tests/W3CTestSuite/PassingTests.txt
+++ b/Tests/W3CTestSuite/PassingTests.txt
@@ -174,6 +174,7 @@ text-ws-02-t.svg
 text-ws-03-t.svg
 types-basic-01-f.svg
 painting-stroke-02-t.svg
+painting-stroke-04-t.svg
 coords-viewattr-04-f.svg
 fonts-desc-01-t.svg
 fonts-elem-05-t.svg


### PR DESCRIPTION
This code implements the function for the property "stroke-dashoffset".
![dashw3ctest](https://user-images.githubusercontent.com/38215829/50499024-2ec28800-0a46-11e9-872b-451a83e66e7f.png)
@mrbean-bremen - could you please check and merge if ok ? 
Issue #388 
Thx.