### PR TITLE
Updates to support multiple dotnet targets v3.5, v4.0, v4.5.2, v4.7.2…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ Tests/**/*.suo
 Source/TestResults/
 Source/.vs
 /Source/Svg.sln.DotSettings.user
+/Source/Svg.XML

--- a/Source/DataTypes/SvgUnitConverter.cs
+++ b/Source/DataTypes/SvgUnitConverter.cs
@@ -1,11 +1,6 @@
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Globalization;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Web.UI.WebControls;
 
 namespace Svg
 {

--- a/Source/Document Structure/SvgGroup.cs
+++ b/Source/Document Structure/SvgGroup.cs
@@ -57,7 +57,7 @@ namespace Svg
         }
 
         /// <summary>
-        /// Gets the <see cref="GraphicsPath"/> for this element.
+        /// Gets the <see cref="System.Drawing.Drawing2D.GraphicsPath"/> for this element.
         /// </summary>
         /// <value></value>
         public override System.Drawing.Drawing2D.GraphicsPath Path(ISvgRenderer renderer)

--- a/Source/Painting/EnumConverters.cs
+++ b/Source/Painting/EnumConverters.cs
@@ -84,6 +84,7 @@ namespace Svg
 
         /// <summary>Creates a new instance.</summary>
         /// <param name="defaultValue">Specified the default value of the enum.</param>
+        /// <param name="caseHandling">Defines if the value shall be converted to lower camel case or lower case</param>
         public EnumBaseConverter(T defaultValue, CaseHandling caseHandling = CaseHandling.CamelCase)
         {
             this.DefaultValue = defaultValue;

--- a/Source/Properties/AssemblyInfo.cs
+++ b/Source/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+#if __EXCLUDED__
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -34,7 +35,7 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 [assembly: AssemblyVersion("2.4.2.*")]
 //[assembly: AssemblyFileVersion("1.0.1.*")]
-
+#endif
 [assembly: CLSCompliant(true)]
 
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Svg.UnitTests,PublicKey=" + 

--- a/Source/Svg.csproj
+++ b/Source/Svg.csproj
@@ -88,6 +88,19 @@ NetStandard does not fully support the Drawing2D package - so has been left out.
     <Reference Include="System.Xml"/>
   </ItemGroup>
 
+  <PropertyGroup>
+    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net35'">$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client</FrameworkPathOverride>
+  </PropertyGroup>
+  <PropertyGroup>
+    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net40'">$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0</FrameworkPathOverride>
+  </PropertyGroup>
+  <PropertyGroup>
+    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net452'">$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5.2</FrameworkPathOverride>
+  </PropertyGroup>
+  <PropertyGroup>
+    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net472'">$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.7.2</FrameworkPathOverride>
+  </PropertyGroup>
+
   <ItemGroup Condition="'$(TargetFramework)'=='net40'">
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Source/Svg.csproj
+++ b/Source/Svg.csproj
@@ -1,8 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net40;netcoreapp2.2;net35;net452;net472</TargetFrameworks>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RootNamespace>Svg</RootNamespace>
     <AssemblyName>Svg</AssemblyName>
+    <IsPackable>true</IsPackable>
     <Company></Company>
     <Authors>davescriven,jvenema,owaits,ddpruitt,Ralf1108,Tebjan Halm,and others</Authors>
     <PackageId>Svg</PackageId>
@@ -24,7 +26,6 @@
     <AssemblyOriginatorKeyFile>svgkey.snk</AssemblyOriginatorKeyFile>
     <AssemblyVersion>2.4.5.0</AssemblyVersion>
     <FileVersion>2.4.5.0</FileVersion>
-    <PackageLicenseUrl>http://opensource.org/licenses/MS-PL.html</PackageLicenseUrl>
     <Version>2.4.5</Version>
     <PackageTags>svg, vector graphics, rendering</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/Source/Svg.csproj
+++ b/Source/Svg.csproj
@@ -1,393 +1,131 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.30729</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{886A98C5-37C0-4E8B-885E-30C1D2F98B47}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <TargetFrameworks>net40;netcoreapp2.2;net35;net452;net472</TargetFrameworks>
     <RootNamespace>Svg</RootNamespace>
     <AssemblyName>Svg</AssemblyName>
-    <RunPostBuildEvent>OnOutputUpdated</RunPostBuildEvent>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <OldToolsVersion>3.5</OldToolsVersion>
-    <UpgradeBackupLocation>
-    </UpgradeBackupLocation>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
-    <IsWebBootstrapper>false</IsWebBootstrapper>
-    <SccProjectName>
-    </SccProjectName>
-    <SccLocalPath>
-    </SccLocalPath>
-    <SccAuxPath>
-    </SccAuxPath>
-    <SccProvider>
-    </SccProvider>
-    <PublishUrl>publish\</PublishUrl>
-    <Install>true</Install>
-    <InstallFrom>Disk</InstallFrom>
-    <UpdateEnabled>false</UpdateEnabled>
-    <UpdateMode>Foreground</UpdateMode>
-    <UpdateInterval>7</UpdateInterval>
-    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
-    <UpdatePeriodically>false</UpdatePeriodically>
-    <UpdateRequired>false</UpdateRequired>
-    <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
-    <UseApplicationTrust>false</UseApplicationTrust>
-    <BootstrapperEnabled>true</BootstrapperEnabled>
-    <TargetFrameworkProfile />
-    <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
-    <NoStdLib>False</NoStdLib>
-    <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
-    <NoWin32Manifest>False</NoWin32Manifest>
-    <DelaySign>False</DelaySign>
-    <AssemblyOriginatorKeyMode>File</AssemblyOriginatorKeyMode>
-    <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugType>Full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>..\..\vvvv\public\common\src\thirdparty\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;REFLECTION</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <DebugSymbols>true</DebugSymbols>
-    <DocumentationFile>
-    </DocumentationFile>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <Company></Company>
+    <Authors>davescriven,jvenema,owaits,ddpruitt,Ralf1108,Tebjan Halm,and others</Authors>
+    <PackageId>Svg</PackageId>
+    <Product>SVG Rendering Library</Product>
+    <Summary>SVG Rendering Library</Summary>
+    <Description>
+      Public fork of the C# SVG rendering library on codeplex: https://svg.codeplex.com/
+      This started out as a minor modification to enable the writing of proper SVG strings. But now after almost two years we have so many fixes and improvements that we decided to share our current codebase to the public in order to improve it even further.
+      So please feel free to fork it and open pull requests for any fix, improvement or feature you add.
+      License: Microsoft Public License: https://svg.codeplex.com/license
+    </Description>
+    <Copyright>Copyright © vvvv.org</Copyright>
+    <Tags>svg, vector graphics, rendering</Tags>
+    <ProjectGuid>{886A98C5-37C0-4E8B-885E-30C1D2F98B47}</ProjectGuid>
+    <DocumentationFile>$(OutputPath)Svg.XML</DocumentationFile>
+    <Configurations>Debug;Release</Configurations>
     <NoWarn>1591</NoWarn>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>PdbOnly</DebugType>
-    <Optimize>True</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRules>
-    </CodeAnalysisRules>
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <DebugSymbols>false</DebugSymbols>
-    <DocumentationFile>bin\Release\Svg.XML</DocumentationFile>
-    <NoWarn>1591</NoWarn>
-  </PropertyGroup>
-  <PropertyGroup>
     <SignAssembly>true</SignAssembly>
-  </PropertyGroup>
-  <PropertyGroup>
     <AssemblyOriginatorKeyFile>svgkey.snk</AssemblyOriginatorKeyFile>
+    <AssemblyVersion>2.4.5.0</AssemblyVersion>
+    <FileVersion>2.4.5.0</FileVersion>
+    <PackageLicenseUrl>http://opensource.org/licenses/MS-PL.html</PackageLicenseUrl>
+    <Version>2.4.5</Version>
+    <PackageTags>svg, vector graphics, rendering</PackageTags>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <PackageReleaseNotes>
+Supports multiple targets v3.5 thru to dotnetcore2.2. 
+NetStandard does not fully support the Drawing2D package - so has been left out.
+    </PackageReleaseNotes>
+    <PackageProjectUrl>https://github.com/vvvv/SVG</PackageProjectUrl>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Web" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Basic Shapes\SvgImage.cs" />
-    <Compile Include="Basic Shapes\SvgMarkerElement.cs" />
-    <Compile Include="Basic Shapes\SvgPathBasedElement.cs" />
-    <Compile Include="Basic Shapes\SvgVisualElement.cs" />
-    <Compile Include="Basic Shapes\SvgCircle.cs" />
-    <Compile Include="Basic Shapes\SvgEllipse.cs" />
-    <Compile Include="Basic Shapes\SvgLine.cs" />
-    <Compile Include="Basic Shapes\SvgPolygon.cs" />
-    <Compile Include="Basic Shapes\SvgPolyline.cs" />
-    <Compile Include="Clipping and Masking\ISvgClipable.cs" />
-    <Compile Include="Clipping and Masking\SvgClipRule.cs" />
-    <Compile Include="Clipping and Masking\SvgClipPath.cs" />
-    <Compile Include="Clipping and Masking\SvgMask.cs" />
-    <Compile Include="DataTypes\ISvgSupportsCoordinateUnits.cs" />
-    <Compile Include="DataTypes\SvgPointCollection.cs" />
-    <Compile Include="DataTypes\SvgTextTransformation.cs" />
-    <Compile Include="DataTypes\SvgTextDecoration.cs" />
-    <Compile Include="DataTypes\SvgTextLengthAdjust.cs" />
-    <Compile Include="DataTypes\SvgTextPathMethod.cs" />
-    <Compile Include="DataTypes\SvgTextPathSpacing.cs" />
-    <Compile Include="DataTypes\XmlSpaceHandling.cs" />
-    <Compile Include="Document Structure\SvgSymbol.cs" />
-    <Compile Include="Exceptions\SvgMemoryException.cs" />
-    <Compile Include="ExtensionMethods\UriExtensions.cs" />
-    <Compile Include="Filter Effects\ImageBuffer.cs" />
-    <Compile Include="Painting\GenericBoundable.cs" />
-    <Compile Include="Painting\SvgFallbackPaintServer .cs" />
-    <Compile Include="Paths\CoordinateParser.cs" />
-    <Compile Include="Rendering\IGraphicsProvider.cs" />
-    <Compile Include="Rendering\ISvgRenderer.cs" />
-    <Compile Include="Rendering\SvgRendering.cs" />
-    <Compile Include="SvgElementStyle.cs" />
-    <Compile Include="SvgFontManager.cs" />
-    <Compile Include="SvgNodeReader.cs" />
-    <Compile Include="Css\CssQuery.cs" />
-    <Compile Include="Css\SvgElementOps.cs" />
-    <Compile Include="DataTypes\SvgAspectRatioConverter.cs" />
-    <Compile Include="DataTypes\SvgFontStyle.cs" />
-    <Compile Include="DataTypes\SvgFontVariant.cs" />
-    <Compile Include="DataTypes\SvgMarkerUnits.cs" />
-    <Compile Include="DataTypes\SvgOrient.cs" />
-    <Compile Include="DataTypes\ISvgViewPort.cs" />
-    <Compile Include="DataTypes\SvgAspectRatio.cs" />
-    <Compile Include="DataTypes\SvgColourInterpolation.cs" />
-    <Compile Include="DataTypes\SvgElementStyle.cs" />
-    <Compile Include="DataTypes\SvgCoordinateUnits.cs" />
-    <Compile Include="DataTypes\SvgFontWeight.cs" />
-    <Compile Include="DataTypes\SvgOrientConverter.cs" />
-    <Compile Include="DataTypes\SvgOverflow.cs" />
-    <Compile Include="DataTypes\SvgUnitCollection.cs" />
-    <Compile Include="DataTypes\SvgViewBox.cs" />
-    <Compile Include="Document Structure\SvgSwitch.cs" />
-    <Compile Include="Document Structure\SvgTitle.cs" />
-    <Compile Include="Document Structure\SvgDocumentMetadata.cs" />
-    <Compile Include="External\ExCSS\IToString.cs" />
-    <Compile Include="External\ExCSS\Lexer.cs" />
-    <Compile Include="External\ExCSS\Model\Enumerations.cs" />
-    <Compile Include="External\ExCSS\Model\Extensions\CharacterExtensions.cs" />
-    <Compile Include="External\ExCSS\Model\Extensions\StringExtensions.cs" />
-    <Compile Include="External\ExCSS\Model\FunctionBuffer.cs" />
-    <Compile Include="External\ExCSS\Model\HtmlEncoding.cs" />
-    <Compile Include="External\ExCSS\Model\ICssRules.cs" />
-    <Compile Include="External\ExCSS\Model\ICssSelector.cs" />
-    <Compile Include="External\ExCSS\Model\IStyleDeclaration.cs" />
-    <Compile Include="External\ExCSS\Model\ISupportsMedia.cs" />
-    <Compile Include="External\ExCSS\Model\MediaTypeList.cs" />
-    <Compile Include="External\ExCSS\Model\Rules\AggregateRule.cs" />
-    <Compile Include="External\ExCSS\Model\Rules\CharacterSetRule.cs" />
-    <Compile Include="External\ExCSS\Model\Rules\ConditionalRule.cs" />
-    <Compile Include="External\ExCSS\Model\Rules\DocumentRule.cs" />
-    <Compile Include="External\ExCSS\Model\Rules\FontFaceRule.cs" />
-    <Compile Include="External\ExCSS\Model\Rules\GenericRule.cs" />
-    <Compile Include="External\ExCSS\Model\Rules\ImportRule.cs" />
-    <Compile Include="External\ExCSS\Model\Rules\IRuleContainer.cs" />
-    <Compile Include="External\ExCSS\Model\Rules\KeyframeRule.cs" />
-    <Compile Include="External\ExCSS\Model\Rules\KeyframesRule.cs" />
-    <Compile Include="External\ExCSS\Model\Rules\MediaRule.cs" />
-    <Compile Include="External\ExCSS\Model\Rules\NamespaceRule.cs" />
-    <Compile Include="External\ExCSS\Model\Rules\PageRule.cs" />
-    <Compile Include="External\ExCSS\Model\Rules\RuleSet.cs" />
-    <Compile Include="External\ExCSS\Model\Rules\StyleDeclaration.cs" />
-    <Compile Include="External\ExCSS\Model\Rules\StyleRule.cs" />
-    <Compile Include="External\ExCSS\Model\Rules\SupportsRule.cs" />
-    <Compile Include="External\ExCSS\Model\Selector\AggregateSelectorList.cs" />
-    <Compile Include="External\ExCSS\Model\Selector\BaseSelector.cs" />
-    <Compile Include="External\ExCSS\Model\Selector\CombinatorSelector.cs" />
-    <Compile Include="External\ExCSS\Model\Selector\ComplexSelector.cs" />
-    <Compile Include="External\ExCSS\Model\Selector\FirstChildSelector.cs" />
-    <Compile Include="External\ExCSS\Model\Selector\LastChildSelector.cs" />
-    <Compile Include="External\ExCSS\Model\Selector\MultipleSelectorList.cs" />
-    <Compile Include="External\ExCSS\Model\Selector\NthChildSelector.cs" />
-    <Compile Include="External\ExCSS\Model\Selector\NthFirstChildSelector.cs" />
-    <Compile Include="External\ExCSS\Model\Selector\NthLastChildSelector.cs" />
-    <Compile Include="External\ExCSS\Model\Selector\NthLastOfTypeSelector.cs" />
-    <Compile Include="External\ExCSS\Model\Selector\NthOfTypeSelector.cs" />
-    <Compile Include="External\ExCSS\Model\Selector\SelectorFactory.cs" />
-    <Compile Include="External\ExCSS\Model\Selector\SelectorList.cs" />
-    <Compile Include="External\ExCSS\Model\Selector\SimpleSelector.cs" />
-    <Compile Include="External\ExCSS\Model\Specification.cs" />
-    <Compile Include="External\ExCSS\Model\TextBlocks\Block.cs" />
-    <Compile Include="External\ExCSS\Model\TextBlocks\BracketBlock.cs" />
-    <Compile Include="External\ExCSS\Model\TextBlocks\CharacterBlock.cs" />
-    <Compile Include="External\ExCSS\Model\TextBlocks\CommentBlock.cs" />
-    <Compile Include="External\ExCSS\Model\TextBlocks\DelimiterBlock.cs" />
-    <Compile Include="External\ExCSS\Model\TextBlocks\MatchBlock.cs" />
-    <Compile Include="External\ExCSS\Model\TextBlocks\NumericBlock.cs" />
-    <Compile Include="External\ExCSS\Model\TextBlocks\PipeBlock.cs" />
-    <Compile Include="External\ExCSS\Model\TextBlocks\RangeBlock.cs" />
-    <Compile Include="External\ExCSS\Model\TextBlocks\SpecialCharacter.cs" />
-    <Compile Include="External\ExCSS\Model\TextBlocks\StringBlock.cs" />
-    <Compile Include="External\ExCSS\Model\TextBlocks\SymbolBlock.cs" />
-    <Compile Include="External\ExCSS\Model\TextBlocks\UnitBlock.cs" />
-    <Compile Include="External\ExCSS\Model\Values\GenericFunction.cs" />
-    <Compile Include="External\ExCSS\Model\Values\HtmlColor.cs" />
-    <Compile Include="External\ExCSS\Model\Values\InheritTerm.cs" />
-    <Compile Include="External\ExCSS\Model\Values\PrimitiveTerm.cs" />
-    <Compile Include="External\ExCSS\Model\Values\Property.cs" />
-    <Compile Include="External\ExCSS\Model\Values\Term.cs" />
-    <Compile Include="External\ExCSS\Model\Values\TermList.cs" />
-    <Compile Include="External\ExCSS\Parser.Blocks.cs" />
-    <Compile Include="External\ExCSS\Parser.cs" />
-    <Compile Include="External\ExCSS\StyleSheet.cs" />
-    <Compile Include="External\ExCSS\StylesheetParseError.cs" />
-    <Compile Include="External\ExCSS\StylesheetReader.cs" />
-    <Compile Include="Extensibility\SvgForeignObject.cs" />
-    <Compile Include="Extensions.cs" />
-    <Compile Include="External\Fizzler\Either.cs" />
-    <Compile Include="External\Fizzler\HumanReadableSelectorGenerator.cs" />
-    <Compile Include="External\Fizzler\IElementOps.cs" />
-    <Compile Include="External\Fizzler\ISelectorGenerator.cs" />
-    <Compile Include="External\Fizzler\NamespacePrefix.cs" />
-    <Compile Include="External\Fizzler\Parser.cs" />
-    <Compile Include="External\Fizzler\Reader.cs" />
-    <Compile Include="External\Fizzler\Selector.cs" />
-    <Compile Include="External\Fizzler\SelectorGenerator.cs" />
-    <Compile Include="External\Fizzler\SelectorGeneratorTee.cs" />
-    <Compile Include="External\Fizzler\SelectorsCachingCompiler.cs" />
-    <Compile Include="External\Fizzler\Token.cs" />
-    <Compile Include="External\Fizzler\Tokener.cs" />
-    <Compile Include="External\Fizzler\TokenKind.cs" />
-    <Compile Include="Painting\ISvgBoundable.cs" />
-    <Compile Include="Painting\SvgDeferredPaintServer.cs" />
-    <Compile Include="Painting\SvgMarker.cs" />
-    <Compile Include="Document Structure\SvgDefinitionList.cs" />
-    <Compile Include="Document Structure\SvgDescription.cs" />
-    <Compile Include="Document Structure\SvgFragment.cs" />
-    <Compile Include="Document Structure\SvgGroup.cs" />
-    <Compile Include="Document Structure\SvgUse.cs" />
-    <Compile Include="Filter Effects\feColourMatrix\SvgColourMatrix.cs" />
-    <Compile Include="Filter Effects\feColourMatrix\SvgColourMatrixType.cs" />
-    <Compile Include="Filter Effects\feGaussianBlur\RawBitmap.cs" />
-    <Compile Include="Filter Effects\feMerge\SvgMergeNode.cs" />
-    <Compile Include="Filter Effects\feOffset\SvgOffset.cs" />
-    <Compile Include="Filter Effects\ISvgFilterable.cs" />
-    <Compile Include="Filter Effects\SvgFilter.cs" />
-    <Compile Include="Filter Effects\SvgFilterPrimitive.cs" />
-    <Compile Include="Filter Effects\feGaussianBlur\SvgGaussianBlur.cs" />
-    <Compile Include="Filter Effects\feMerge\SvgMerge.cs" />
-    <Compile Include="Painting\EnumConverters.cs" />
-    <Compile Include="SvgContentNode.cs" />
-    <Compile Include="SvgDefinitionDefaults.cs" />
-    <Compile Include="NonSvgElement.cs" />
-    <Compile Include="SvgUnknownElement.cs" />
-    <Compile Include="SvgElementAttribute.cs" />
-    <Compile Include="SvgExtentions.cs" />
-    <Compile Include="Rendering\SvgRenderer.cs" />
-    <Compile Include="Painting\SvgColourConverter.cs" />
-    <Compile Include="Painting\SvgGradientSpreadMethod.cs" />
-    <Compile Include="SvgDtdResolver.cs" />
-    <Compile Include="Exceptions\SvgException.cs" />
-    <Compile Include="Painting\SvgFillRule.cs" />
-    <Compile Include="Painting\SvgGradientServer.cs" />
-    <Compile Include="Painting\SvgGradientStop.cs" />
-    <Compile Include="Painting\ISvgStylable.cs" />
-    <Compile Include="Painting\SvgColourServer.cs" />
-    <Compile Include="Painting\SvgLinearGradientServer.cs" />
-    <Compile Include="Painting\SvgPaintServer.cs" />
-    <Compile Include="Painting\SvgPaintServerFactory.cs" />
-    <Compile Include="Painting\SvgPatternServer.cs" />
-    <Compile Include="Painting\SvgRadialGradientServer.cs" />
-    <Compile Include="Painting\SvgStrokeLineCap.cs" />
-    <Compile Include="Painting\SvgStrokeLineJoin.cs" />
-    <Compile Include="Basic Shapes\SvgVisualElementStyle.cs" />
-    <Compile Include="Paths\SvgArcSegment.cs" />
-    <Compile Include="Paths\SvgClosePathSegment.cs" />
-    <Compile Include="Paths\SvgCubicCurveSegment.cs" />
-    <Compile Include="Paths\SvgLineSegment.cs" />
-    <Compile Include="Paths\SvgMoveToSegment.cs" />
-    <Compile Include="Paths\SvgPath.cs" />
-    <Compile Include="Basic Shapes\SvgRectangle.cs" />
-    <Compile Include="Paths\SvgPathSegment.cs" />
-    <Compile Include="Paths\SvgPathSegmentList.cs" />
-    <Compile Include="Paths\SvgQuadraticCurveSegment.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="SvgDocument.cs" />
-    <Compile Include="SvgAttributeAttribute.cs" />
-    <Compile Include="SvgAttributeCollection.cs" />
-    <Compile Include="SvgElement.cs" />
-    <Compile Include="SvgElementCollection.cs" />
-    <Compile Include="SvgElementFactory.cs" />
-    <Compile Include="Paths\SvgPathBuilder.cs" />
-    <Compile Include="DataTypes\SvgPoint.cs" />
-    <Compile Include="SvgElementIdManager.cs" />
-    <Compile Include="DataTypes\SvgUnit.cs" />
-    <Compile Include="DataTypes\SvgUnitConverter.cs" />
-    <Compile Include="SvgTextReader.cs" />
-    <Compile Include="Text\SvgFontFaceUri.cs" />
-    <Compile Include="Text\FontFamily.cs" />
-    <Compile Include="Text\GdiFontDefn.cs" />
-    <Compile Include="Text\IFontDefn.cs" />
-    <Compile Include="Text\SvgFont.cs" />
-    <Compile Include="Text\SvgFontDefn.cs" />
-    <Compile Include="Text\SvgFontFace.cs" />
-    <Compile Include="Text\SvgFontFaceSrc.cs" />
-    <Compile Include="Text\SvgGlyph.cs" />
-    <Compile Include="Text\SvgKern.cs" />
-    <Compile Include="Text\SvgMissingGlyph.cs" />
-    <Compile Include="Text\SvgText.cs" />
-    <Compile Include="Text\SvgTextBase.cs" />
-    <Compile Include="Text\SvgTextAnchor.cs" />
-    <Compile Include="Text\SvgTextPath.cs" />
-    <Compile Include="Text\SvgTextSpan.cs" />
-    <Compile Include="Text\SvgTextRef.cs" />
-    <Compile Include="Text\PathStatistics.cs" />
-    <Compile Include="Transforms\ISvgTransformable.cs" />
-    <Compile Include="Transforms\SvgMatrix.cs" />
-    <Compile Include="Transforms\SvgRotate.cs" />
-    <Compile Include="Transforms\SvgScale.cs" />
-    <Compile Include="Transforms\SvgShear.cs" />
-    <Compile Include="Transforms\SvgSkew.cs" />
-    <Compile Include="Transforms\SvgTransform.cs" />
-    <Compile Include="Transforms\SvgTransformCollection.cs" />
-    <Compile Include="Transforms\SvgTransformConverter.cs" />
-    <Compile Include="Transforms\SvgTranslate.cs" />
-    <Compile Include="Web\SvgHandler.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.2.0">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 2.0 %28x86%29</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.0">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.0 %28x86%29</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-  </ItemGroup>
+
   <ItemGroup>
     <EmbeddedResource Include="Resources\svg11.dtd" />
-  </ItemGroup>
-  <ItemGroup>
     <Folder Include="Web\Resources\" />
-  </ItemGroup>
-  <ItemGroup>
     <None Include="Basic Shapes\DOM.cd" />
-    <None Include="Svg.nuspec" />
     <None Include="svgkey.snk" />
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
-  <PropertyGroup>
-    <PostBuildEvent>
-    </PostBuildEvent>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
+    <DefineConstants>$(DefineConstants);TRACE;DEBUG</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Platform)' == 'AnyCPU' ">
-    <RegisterForComInterop>False</RegisterForComInterop>
-    <GenerateSerializationAssemblies>Auto</GenerateSerializationAssemblies>
-    <BaseAddress>4194304</BaseAddress>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <FileAlignment>4096</FileAlignment>
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <DefineConstants>$(DefineConstants);TRACE;RELEASE</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-    <CheckForOverflowUnderflow>False</CheckForOverflowUnderflow>
+
+  <PropertyGroup Condition="'$(TargetFramework)'=='net35'">
+    <Title>Svg for .Net Framework 3.5</Title>
+    <DefineConstants>$(DefineConstants);NETFULL;NET35</DefineConstants>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <CheckForOverflowUnderflow>False</CheckForOverflowUnderflow>
-    <BaseIntermediateOutputPath>obj\</BaseIntermediateOutputPath>
+
+  <PropertyGroup Condition="'$(TargetFramework)'=='net40'">
+    <Title>Svg for .Net Framework 4.0</Title>
+    <DefineConstants>$(DefineConstants);NETFULL;NET40</DefineConstants>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)'=='net452'">
+    <Title>Svg for .Net Framework 4.5.2</Title>
+    <DefineConstants>$(DefineConstants);NETFULL;NET452</DefineConstants>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)'=='net472'">
+    <Title>Svg for .Net Framework 4.7.2</Title>
+    <DefineConstants>$(DefineConstants);NETFULL;NET472</DefineConstants>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp2.2'">
+    <Title>Svg for .Net Core 2.2</Title>
+    <DefineConstants>$(DefineConstants);NETCORE;NETCORE22</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='net35'">
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Xml"/>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='net40'">
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Xml"/>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='net452'">
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Xml"/>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='net472'">
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Xml"/>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.2'">
+    <PackageReference Include="System.Drawing.Common">
+      <Version>4.5.1</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove=".\External\ExCSS\Parser.generated.cs" />
+    <Compile Remove=".\External\ExCSS\ParserX.cs" />
+    <Compile Remove=".\Resources\svg11.dtd" />
+    <None Remove="Local.testsettings" />
+    <None Remove="Svg.csproj.vspscc" />
+    <None Remove="Svg.nuspec" />
+    <None Remove="Svg.vsmdi" />
+    <None Remove="Svg.XML" />
+  </ItemGroup>
 </Project>

--- a/Source/Svg.sln
+++ b/Source/Svg.sln
@@ -1,13 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.168
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Svg", "Svg.csproj", "{886A98C5-37C0-4E8B-885E-30C1D2F98B47}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Svg", "Svg.csproj", "{886A98C5-37C0-4E8B-885E-30C1D2F98B47}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SVGViewer", "..\Samples\SVGViewer\SVGViewer.csproj", "{1B8F3C8A-CCAC-474E-B09D-522FBA93DCFD}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Svg.UnitTests", "..\Tests\Svg.UnitTests\Svg.UnitTests.csproj", "{E702EB7D-D01D-438A-BADD-E72D4E49109F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Svg.UnitTests", "..\Tests\Svg.UnitTests\Svg.UnitTests.csproj", "{E702EB7D-D01D-438A-BADD-E72D4E49109F}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A417AF1E-BEDB-4715-B4FD-D795579217F9}"
 	ProjectSection(SolutionItems) = preProject
@@ -15,10 +13,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Svg.vsmdi = Svg.vsmdi
 		TraceAndTestImpact.testsettings = TraceAndTestImpact.testsettings
 	EndProjectSection
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SvgW3CTestRunner", "..\Tests\SvgW3CTestRunner\SvgW3CTestRunner.csproj", "{8ED74C39-6CFF-421E-952A-30F9E6957108}"
-EndProject
-Project("{FF286327-C783-4F7A-AB73-9BCBAD0D4460}") = "Svg.Package", "SvgNuget\Svg.Package.nuproj", "{AEEFC0CC-6D17-439D-B8E0-53B713485E3B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -40,18 +34,6 @@ Global
 		{886A98C5-37C0-4E8B-885E-30C1D2F98B47}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{886A98C5-37C0-4E8B-885E-30C1D2F98B47}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{886A98C5-37C0-4E8B-885E-30C1D2F98B47}.Release|x86.ActiveCfg = Release|Any CPU
-		{1B8F3C8A-CCAC-474E-B09D-522FBA93DCFD}.Debug|Any CPU.ActiveCfg = Release|Any CPU
-		{1B8F3C8A-CCAC-474E-B09D-522FBA93DCFD}.Debug|Any CPU.Build.0 = Release|Any CPU
-		{1B8F3C8A-CCAC-474E-B09D-522FBA93DCFD}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{1B8F3C8A-CCAC-474E-B09D-522FBA93DCFD}.Debug|Mixed Platforms.Build.0 = Debug|x86
-		{1B8F3C8A-CCAC-474E-B09D-522FBA93DCFD}.Debug|x86.ActiveCfg = Debug|x86
-		{1B8F3C8A-CCAC-474E-B09D-522FBA93DCFD}.Debug|x86.Build.0 = Debug|Any CPU
-		{1B8F3C8A-CCAC-474E-B09D-522FBA93DCFD}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{1B8F3C8A-CCAC-474E-B09D-522FBA93DCFD}.Release|Any CPU.Build.0 = Release|Any CPU
-		{1B8F3C8A-CCAC-474E-B09D-522FBA93DCFD}.Release|Mixed Platforms.ActiveCfg = Release|x86
-		{1B8F3C8A-CCAC-474E-B09D-522FBA93DCFD}.Release|Mixed Platforms.Build.0 = Release|x86
-		{1B8F3C8A-CCAC-474E-B09D-522FBA93DCFD}.Release|x86.ActiveCfg = Release|Any CPU
-		{1B8F3C8A-CCAC-474E-B09D-522FBA93DCFD}.Release|x86.Build.0 = Release|Any CPU
 		{E702EB7D-D01D-438A-BADD-E72D4E49109F}.Debug|Any CPU.ActiveCfg = Release|Any CPU
 		{E702EB7D-D01D-438A-BADD-E72D4E49109F}.Debug|Any CPU.Build.0 = Release|Any CPU
 		{E702EB7D-D01D-438A-BADD-E72D4E49109F}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
@@ -62,33 +44,12 @@ Global
 		{E702EB7D-D01D-438A-BADD-E72D4E49109F}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{E702EB7D-D01D-438A-BADD-E72D4E49109F}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{E702EB7D-D01D-438A-BADD-E72D4E49109F}.Release|x86.ActiveCfg = Release|Any CPU
-		{8ED74C39-6CFF-421E-952A-30F9E6957108}.Debug|Any CPU.ActiveCfg = Release|x86
-		{8ED74C39-6CFF-421E-952A-30F9E6957108}.Debug|Any CPU.Build.0 = Release|x86
-		{8ED74C39-6CFF-421E-952A-30F9E6957108}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{8ED74C39-6CFF-421E-952A-30F9E6957108}.Debug|Mixed Platforms.Build.0 = Debug|x86
-		{8ED74C39-6CFF-421E-952A-30F9E6957108}.Debug|x86.ActiveCfg = Debug|x86
-		{8ED74C39-6CFF-421E-952A-30F9E6957108}.Debug|x86.Build.0 = Debug|x86
-		{8ED74C39-6CFF-421E-952A-30F9E6957108}.Release|Any CPU.ActiveCfg = Release|x86
-		{8ED74C39-6CFF-421E-952A-30F9E6957108}.Release|Any CPU.Build.0 = Release|x86
-		{8ED74C39-6CFF-421E-952A-30F9E6957108}.Release|Mixed Platforms.ActiveCfg = Release|x86
-		{8ED74C39-6CFF-421E-952A-30F9E6957108}.Release|Mixed Platforms.Build.0 = Release|x86
-		{8ED74C39-6CFF-421E-952A-30F9E6957108}.Release|x86.ActiveCfg = Release|x86
-		{8ED74C39-6CFF-421E-952A-30F9E6957108}.Release|x86.Build.0 = Release|x86
-		{AEEFC0CC-6D17-439D-B8E0-53B713485E3B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{AEEFC0CC-6D17-439D-B8E0-53B713485E3B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{AEEFC0CC-6D17-439D-B8E0-53B713485E3B}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{AEEFC0CC-6D17-439D-B8E0-53B713485E3B}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{AEEFC0CC-6D17-439D-B8E0-53B713485E3B}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{AEEFC0CC-6D17-439D-B8E0-53B713485E3B}.Debug|x86.Build.0 = Debug|Any CPU
-		{AEEFC0CC-6D17-439D-B8E0-53B713485E3B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{AEEFC0CC-6D17-439D-B8E0-53B713485E3B}.Release|Any CPU.Build.0 = Release|Any CPU
-		{AEEFC0CC-6D17-439D-B8E0-53B713485E3B}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{AEEFC0CC-6D17-439D-B8E0-53B713485E3B}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{AEEFC0CC-6D17-439D-B8E0-53B713485E3B}.Release|x86.ActiveCfg = Release|Any CPU
-		{AEEFC0CC-6D17-439D-B8E0-53B713485E3B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {5096EEB3-8F41-44B5-BCF9-58743A59AB21}
 	EndGlobalSection
 	GlobalSection(TestCaseManagementSettings) = postSolution
 		CategoryFile = Svg.vsmdi

--- a/Source/SvgDocument.cs
+++ b/Source/SvgDocument.cs
@@ -230,9 +230,10 @@ namespace Svg
 
             using (var strReader = new System.IO.StringReader(svg))
             {
-                var reader = new SvgTextReader(strReader, null);
-                reader.XmlResolver = new SvgDtdResolver();
-                reader.WhitespaceHandling = WhitespaceHandling.None;
+                var reader = new SvgTextReader(strReader, null)
+                {
+                    XmlResolver = new SvgDtdResolver(), WhitespaceHandling = WhitespaceHandling.None
+                };
                 return Open<T>(reader);
             }
         }
@@ -251,9 +252,10 @@ namespace Svg
             }
 
             // Don't close the stream via a dispose: that is the client's job.
-            var reader = new SvgTextReader(stream, entities);
-            reader.XmlResolver = new SvgDtdResolver();
-            reader.WhitespaceHandling = WhitespaceHandling.None;
+            var reader = new SvgTextReader(stream, entities)
+            {
+                XmlResolver = new SvgDtdResolver(), WhitespaceHandling = WhitespaceHandling.None
+            };
             return Open<T>(reader);
         }
 
@@ -613,8 +615,10 @@ namespace Svg
         public void Write(Stream stream, bool useBom = true)
         {
 
-            var xmlWriter = new XmlTextWriter(stream, useBom ? Encoding.UTF8 : new System.Text.UTF8Encoding(false));
-            xmlWriter.Formatting = Formatting.Indented;
+            var xmlWriter = new XmlTextWriter(stream, useBom ? Encoding.UTF8 : new System.Text.UTF8Encoding(false))
+            {
+                Formatting = Formatting.Indented
+            };
             xmlWriter.WriteStartDocument();
             xmlWriter.WriteDocType("svg", "-//W3C//DTD SVG 1.1//EN", "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd", null);
             

--- a/Source/SvgElement.cs
+++ b/Source/SvgElement.cs
@@ -582,7 +582,12 @@ namespace Svg
                     (!attr.Attribute.InAttributeDictionary || _attributes.ContainsKey(attr.Attribute.Name)))
                 {
                     object propertyValue = attr.Property.GetValue(this);
+#if NETFULL
                     string value = (string)attr.Property.Converter.ConvertTo(propertyValue, typeof(string));
+#else
+                    //dotnetcore throws exception if input is null
+    string value = propertyValue==null?null:(string)attr.Property.Converter.ConvertTo(propertyValue, typeof(string));
+#endif
 
                     forceWrite = false;
                     writeStyle = attr.Attribute.Name == "fill" || attr.Attribute.Name == "stroke";

--- a/Source/Web/SvgHandler.cs
+++ b/Source/Web/SvgHandler.cs
@@ -1,3 +1,4 @@
+#if __EXCLUDED__
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -231,3 +232,4 @@ namespace Svg.Web
         }
     }
 }
+#endif

--- a/Tests/Svg.UnitTests/ImageComparisonTest.cs
+++ b/Tests/Svg.UnitTests/ImageComparisonTest.cs
@@ -55,15 +55,14 @@ namespace Svg.UnitTests
         //public void CompareSvgImageWithReference()
         public void CompareSvgImageWithReference(string basePath, string baseName)
         {
+            bool testSaveLoad = !baseName.StartsWith("#");
+            if (!testSaveLoad)
+            {
+                baseName = baseName.Substring(1);
+            }
             var svgPath = Path.Combine(basePath, "svg", baseName + ".svg");
             var pngPath = Path.Combine(basePath, "png", baseName + ".png");
-            var pngImage = Image.FromFile(pngPath);
-            var svgImage = LoadSvgImage(baseName, svgPath);
-            Assert.AreNotEqual(null, pngImage, "Failed to load " + pngPath);
-            Assert.AreNotEqual(null, svgImage, "Failed to load " + svgPath);
-            var difference = svgImage.PercentageDifference(pngImage);
-            Assert.IsTrue(difference < 0.05, 
-                baseName + ": Difference is " + (difference * 100.0).ToString() + "%");
+            CompareSvgImageWithReferenceImpl(baseName, svgPath, pngPath, testSaveLoad);
         }
 #else
         [TestMethod]
@@ -87,6 +86,13 @@ namespace Svg.UnitTests
             }
             var svgPath = Path.Combine(Path.Combine(basePath, "svg"), baseName + ".svg");
             var pngPath = Path.Combine(Path.Combine(basePath, "png"), baseName + ".png");
+            CompareSvgImageWithReferenceImpl(baseName, svgPath, pngPath, testSaveLoad);
+        }
+#endif
+
+        private void CompareSvgImageWithReferenceImpl(string baseName, 
+            string svgPath, string pngPath, bool testSaveLoad)
+        {
             var pngImage = Image.FromFile(pngPath);
             var svgDoc = LoadSvgDocument(svgPath);
             Assert.IsNotNull(svgDoc);
@@ -121,7 +127,6 @@ namespace Svg.UnitTests
                     baseName + ": Difference is " + (difference * 100.0).ToString() + "%");
             }
         }
-#endif
 
         /// <summary>
         /// Enable this test to output the calculate percentage difference

--- a/Tests/Svg.UnitTests/MultiThreadingTest.cs
+++ b/Tests/Svg.UnitTests/MultiThreadingTest.cs
@@ -1,3 +1,5 @@
+#if NET35
+#else 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Svg.Exceptions;
 using System;
@@ -37,3 +39,4 @@ namespace Svg.UnitTests
         }
     }
 }
+#endif

--- a/Tests/Svg.UnitTests/Properties/AssemblyInfo.cs
+++ b/Tests/Svg.UnitTests/Properties/AssemblyInfo.cs
@@ -1,35 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("Svg.UnitTests")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Svg.UnitTests")]
-[assembly: AssemblyCopyright("Copyright ©  2014")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("6ab1d266-f201-46c0-9d14-523768eb18db")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Tests/Svg.UnitTests/Svg.UnitTests.csproj
+++ b/Tests/Svg.UnitTests/Svg.UnitTests.csproj
@@ -1,85 +1,49 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>
-    </ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{E702EB7D-D01D-438A-BADD-E72D4E49109F}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Svg.UnitTests</RootNamespace>
-    <AssemblyName>Svg.UnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.2;net35;net40;net452;net472</TargetFrameworks>
+    <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>
-  </PropertyGroup>
-  <PropertyGroup>
     <AssemblyOriginatorKeyFile>svgkey.snk</AssemblyOriginatorKeyFile>
+    <DelaySign>false</DelaySign>
+    <Configurations>Debug;Release</Configurations>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="System" />
-    <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Data" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Web" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
-      <Visible>False</Visible>
-    </CodeAnalysisDependentAssemblyPaths>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="BoundsTests.cs" />
-    <Compile Include="CssQueryTest.cs" />
-    <Compile Include="LargeEmbeddedImageTest.cs" />
-    <Compile Include="LexerIssueTests.cs" />
-    <Compile Include="MarkerEndTest.cs" />
-    <Compile Include="MetafileRenderingTest.cs" />
-    <Compile Include="MultiThreadingTest.cs" />
-    <Compile Include="PrivateFontsTests.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="SmallEmbeddingImageTest.cs" />
-    <Compile Include="SvgPointCollectionTests.cs" />
-    <Compile Include="SvgTestHelper.cs" />
-    <Compile Include="SvgTextTests.cs" />
-    <Compile Include="SvgTextElementDeepCopyTest.cs" />
-    <Compile Include="ImageComparisonTest.cs" />
-    <Compile Include="PercentageSizeTests.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\Source\Svg.csproj">
-      <Project>{886A98C5-37C0-4E8B-885E-30C1D2F98B47}</Project>
-      <Name>Svg</Name>
-    </ProjectReference>
-  </ItemGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net35|AnyCPU'">
+    <DefineConstants>TRACE;DEBUG;NETFULL;NET35</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net35|AnyCPU'">
+    <DefineConstants>TRACE;RELEASE;NETFULL;NET35</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net40|AnyCPU'">
+    <DefineConstants>TRACE;DEBUG;NETFULL;NET40</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net40|AnyCPU'">
+    <DefineConstants>TRACE;RELEASE;NETFULL;NET40</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net452|AnyCPU'">
+    <DefineConstants>TRACE;DEBUG;NETFULL;NET452</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net452|AnyCPU'">
+    <DefineConstants>TRACE;RELEASE;NETFULL;NET452</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net472|AnyCPU'">
+    <DefineConstants>TRACE;DEBUG;NETFULL;NET472</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net472|AnyCPU'">
+    <DefineConstants>TRACE;RELEASE;NETFULL;NET472</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netcoreapp2.2|AnyCPU'">
+    <DefineConstants>TRACE;RELEASE;NETCORE</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp2.2|AnyCPU'">
+    <DefineConstants>TRACE;DEBUG;NETCORE</DefineConstants>
+  </PropertyGroup>
+
+
   <ItemGroup>
     <EmbeddedResource Include="Resources\Issue204_PrivateFont\BrushScriptMT2.ttf" />
+    <None Include="packages.config" />
     <None Include="AllTests.csv" />
     <None Include="PassingTests.csv" />
     <None Include="svgkey.snk" />
@@ -108,16 +72,36 @@
   <ItemGroup>
     <EmbeddedResource Include="Resources\Issue_Threading\TestFile.svg" />
   </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="Resources\Issue399_LexerIssue\LexerTestTemplate.svg" />
-    <EmbeddedResource Include="Resources\Issue399_LexerIssue\EmptyDTag.svg" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.2'">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net35'">
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework">
+      <HintPath>C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\ReferenceAssemblies\v4.0\Microsoft.VisualStudio.QualityTools.UnitTestFramework.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net40'">
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework">
+      <HintPath>C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\ReferenceAssemblies\v4.0\Microsoft.VisualStudio.QualityTools.UnitTestFramework.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Source\SVG.csproj" />
+  </ItemGroup>
+
+
 </Project>

--- a/Tests/Svg.UnitTests/Svg.UnitTests.csproj
+++ b/Tests/Svg.UnitTests/Svg.UnitTests.csproj
@@ -99,6 +99,19 @@
     </Reference>
   </ItemGroup>
 
+  <PropertyGroup>
+    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net35'">$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client</FrameworkPathOverride>
+  </PropertyGroup>
+  <PropertyGroup>
+    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net40'">$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0</FrameworkPathOverride>
+  </PropertyGroup>
+  <PropertyGroup>
+    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net452'">$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5.2</FrameworkPathOverride>
+  </PropertyGroup>
+  <PropertyGroup>
+    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net472'">$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.7.2</FrameworkPathOverride>
+  </PropertyGroup>
+
 
   <ItemGroup>
     <ProjectReference Include="..\..\Source\SVG.csproj" />

--- a/Tests/Svg.UnitTests/Svg.UnitTests.csproj
+++ b/Tests/Svg.UnitTests/Svg.UnitTests.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <IsTestProject>true</IsTestProject>
     <TargetFrameworks>netcoreapp2.2;net35;net40;net452;net472</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>

--- a/Tests/Svg.UnitTests/Svg.UnitTests.csproj
+++ b/Tests/Svg.UnitTests/Svg.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsTestProject>true</IsTestProject>
-    <TargetFrameworks>netcoreapp2.2;net35;net40;net452;net472</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.2;net40;net452;net472</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>svgkey.snk</AssemblyOriginatorKeyFile>
@@ -102,6 +102,7 @@
   <PropertyGroup>
     <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net35'">$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client</FrameworkPathOverride>
   </PropertyGroup>
+  <!--
   <PropertyGroup>
     <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net40'">$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0</FrameworkPathOverride>
   </PropertyGroup>
@@ -111,6 +112,7 @@
   <PropertyGroup>
     <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net472'">$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.7.2</FrameworkPathOverride>
   </PropertyGroup>
+  -->
 
 
   <ItemGroup>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ configuration:
 - Release
 before_build:
 - ps: nuget restore Source\Svg.csproj
-- ps: nuget restore Tests\Svg.UnitTestsSvg.UnitTests.csproj
+- ps: nuget restore Tests\Svg.UnitTests\Svg.UnitTests.csproj
 build:
   project: Source\Svg.sln
 test:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,3 @@ before_build:
 - ps: nuget restore Tests\Svg.UnitTests\Svg.UnitTests.csproj
 build:
   project: Source\Svg.sln
-test:
-  assemblies:
-    - '**\Svg.UnitTests.dll'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,5 +2,7 @@ version: '{build}'
 image: Visual Studio 2017
 configuration:
 - Release
+before_build:
+- ps: nuget restore Source\Svg.csproj
 build:
   project: Tests\Svg.UnitTests\Svg.UnitTests.csproj

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
+version: '{build}'
+image: Visual Studio 2017
 configuration:
-  - Release
-  
+- Release
 build:
   project: Tests\Svg.UnitTests\Svg.UnitTests.csproj

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,5 +2,11 @@ version: '{build}'
 image: Visual Studio 2017
 configuration:
 - Release
+before_build:
+- ps: nuget restore Source\Svg.csproj
+- ps: nuget restore Tests\Svg.UnitTestsSvg.UnitTests.csproj
 build:
   project: Source\Svg.sln
+test:
+  assemblies:
+    - '**\Svg.UnitTests.dll'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,5 @@ version: '{build}'
 image: Visual Studio 2017
 configuration:
 - Release
-before_build:
-- ps: nuget restore Source\Svg.csproj
 build:
-  project: Tests\Svg.UnitTests\Svg.UnitTests.csproj
+  project: Source\Svg.sln

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 version: '{build}'
+
 image: Visual Studio 2017
 configuration:
 - Release


### PR DESCRIPTION
… and dotnetcore2.2

I require dotnetcore2.2 version. While I was in the process, I also added v3.5,v4.0, v4.5.2 and v.4.7.2.
DotnetStandard is a little more complex as it does not fully support System.Drawing.Drawing2D.

In the process I have also updated the tests to support all frameworks.

I have also updated the appveyor.yml script - but don't know how to test it without raising this pull-request. (Is is possible?).