### PR TITLE
Fix: character corruption.

### DIFF
--- a/Samples/SVGViewer/SvgViewer.cs
+++ b/Samples/SVGViewer/SvgViewer.cs
@@ -44,11 +44,8 @@ namespace SVGViewer
         {
             try
             {
-                using (var s = new MemoryStream(Encoding.UTF8.GetBytes(textBox1.Text)))
-                {
-                    SvgDocument svgDoc = SvgDocument.Open<SvgDocument>(s, null);
-                    RenderSvg(svgDoc);
-                }
+                SvgDocument svgDoc = SvgDocument.FromSvg<SvgDocument>(textBox1.Text);
+                RenderSvg(svgDoc);
             }
             catch
             {


### PR DESCRIPTION
- use FromSvg method.

### Sample SVG
```svg
<?xml version="1.0" encoding="shift_jis"?>
<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0" y="0" width="80" height="400" xml:space="preserve">
<text x="10" y="30" fill="#000" font-size="14">あABC</text>
</svg>
```

### Character corruption
![issue_output](https://user-images.githubusercontent.com/11144112/53852881-da6bf380-4006-11e9-99bb-7d839c5992a6.png)
