### PR TITLE
Fix: xlink:href value format.

### DIFF
--- a/Source/SvgElement.cs
+++ b/Source/SvgElement.cs
@@ -656,15 +656,13 @@ namespace Svg
                         var value = (string)attr.Property.Converter.ConvertTo(propertyValue, typeof(string));
 #else
                         // dotnetcore throws exception if input is null
-                        string value = propertyValue==null?null:(string)attr.Property.Converter.ConvertTo(propertyValue, typeof(string));
+                        var value = propertyValue == null ? null : (string)attr.Property.Converter.ConvertTo(propertyValue, typeof(string));
 #endif
 
                         if (propertyValue != null)
                         {
-                            var type = propertyValue.GetType();
-
                             //Only write the attribute's value if it is not the default value, not null/empty, or we're forcing the write.
-                            if ((!string.IsNullOrEmpty(value) && !SvgDefaults.IsDefault(attr.Attribute.Name, attr.Property.ComponentType.Name, value)) || forceWrite)
+                            if (forceWrite || (!string.IsNullOrEmpty(value) && !SvgDefaults.IsDefault(attr.Attribute.Name, attr.Property.ComponentType.Name, value)))
                             {
                                 if (writeStyle)
                                 {

--- a/Source/SvgElement.cs
+++ b/Source/SvgElement.cs
@@ -3,12 +3,11 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
 using System.Drawing.Drawing2D;
-using System.Xml;
 using System.Linq;
-using Svg.Transforms;
 using System.Reflection;
-using System.Threading;
-using System.Globalization;
+using System.Text;
+using System.Xml;
+using Svg.Transforms;
 
 namespace Svg
 {
@@ -661,6 +660,12 @@ namespace Svg
 
                         if (propertyValue != null)
                         {
+                            if (!string.IsNullOrEmpty(value))
+                            {
+                                if (attr.Attribute.NamespaceAndName == "xlink:href" && value.StartsWith("url("))
+                                    value = new StringBuilder(value).Remove(value.Length - 1, 1).Remove(0, 4).ToString();
+                            }
+
                             //Only write the attribute's value if it is not the default value, not null/empty, or we're forcing the write.
                             if (forceWrite || (!string.IsNullOrEmpty(value) && !SvgDefaults.IsDefault(attr.Attribute.Name, attr.Property.ComponentType.Name, value)))
                             {


### PR DESCRIPTION
Format of xlink:href value is invalid.
So, output SVG file is not rendered on browsers.

For example, part of `pservers-grad-01-b.svg` SVG file output.

- Input
```svg
    <linearGradient id="Grad1b" xlink:href="#Grad1a"/>
```

- Output
```svg
    <linearGradient y2="0%" gradientUnits="objectBoundingBox" xlink:href="url(#Grad1a)" id="Grad1b" xml:space="default" />
```

- Expected
```svg
    <linearGradient y2="0%" gradientUnits="objectBoundingBox" xlink:href="#Grad1a" id="Grad1b" xml:space="default" />
```