### PR TITLE
Sample design code for BaseUri.

### DIFF
--- a/Source/Basic Shapes/SvgImage.cs
+++ b/Source/Basic Shapes/SvgImage.cs
@@ -304,8 +304,7 @@ namespace Svg
                         }
                         if (uri.LocalPath.EndsWith(".svg", StringComparison.InvariantCultureIgnoreCase))
                         {
-                            var doc = SvgDocument.Open<SvgDocument>(stream);
-                            doc.BaseUri = uri;
+                            var doc = SvgDocument.Open<SvgDocument>(stream, uri);
                             return doc;
                         }
                         else

--- a/Source/SvgElementIdManager.cs
+++ b/Source/SvgElementIdManager.cs
@@ -59,7 +59,7 @@ namespace Svg
                         var httpRequest = WebRequest.Create(uri);
                         using (var webResponse = httpRequest.GetResponse())
                         {
-                            var doc = SvgDocument.Open<SvgDocument>(webResponse.GetResponseStream());
+                            var doc = SvgDocument.Open<SvgDocument>(webResponse.GetResponseStream(), uri);
                             return doc.IdManager.GetElementById(fragment);
                         }
                     }

--- a/Tests/Svg.UnitTests/ImageComparisonTest.cs
+++ b/Tests/Svg.UnitTests/ImageComparisonTest.cs
@@ -114,12 +114,8 @@ namespace Svg.UnitTests
             {
                 svgDoc.Write(memStream);
                 memStream.Position = 0;
-                var reader = new StreamReader(memStream);
-                var tempFilePath = Path.Combine(Path.GetTempPath(), "test.svg");
-                File.WriteAllText(tempFilePath, reader.ReadToEnd());
                 var baseUri = svgDoc.BaseUri;
-                svgDoc = SvgDocument.Open(tempFilePath);
-                svgDoc.BaseUri = baseUri;
+                svgDoc = SvgDocument.Open<SvgDocument>(memStream, baseUri);
                 svgImage = LoadSvgImage(svgDoc, useFixedSize);
                 Assert.IsNotNull(svgImage);
                 difference = svgImage.PercentageDifference(pngImage);

--- a/Tests/SvgW3CTestRunner/View.cs
+++ b/Tests/SvgW3CTestRunner/View.cs
@@ -117,13 +117,8 @@ namespace SvgW3CTestRunner
                 {
                     doc.Write(memStream);
                     memStream.Position = 0;  
-                    var reader = new StreamReader(memStream);
-                    var tempFilePath = Path.Combine(Path.GetTempPath(), "test.svg");
-                    System.IO.File.WriteAllText(tempFilePath, reader.ReadToEnd());
-                    memStream.Position = 0;
                     var baseUri = doc.BaseUri;
-                    doc = SvgDocument.Open(tempFilePath);
-                    doc.BaseUri = baseUri;
+                    doc = SvgDocument.Open<SvgDocument>(memStream, baseUri);
                     
                     if (fileName.StartsWith("__"))
                     {


### PR DESCRIPTION
I am considering relative paths in SVG.

Rough flow is below.

1. `Open`
2. `FlushStyles`
3. In `Open` method if exists path, then set `BaseUri` property
4. set `BaseUri` property
5. `Draw`

In 2. `FlushStyles`, `SvgPaintServerFactory` tries to resolve link values, but can not because it does not have base URI for relative path.

This PR is an implementation to set `BaseUri` in 1. `Open` and changes from clients are **not acceptable**.
This is better way, I think.

However, compatibility is broken because access attribute of `BaseUri` set property changes.

Need to keep `BaseUri` set property public ?