### PR TITLE
Resolve: #138 'linearGradient not exported correctly if id begins with number' issue.

### DIFF
--- a/Source/SvgElementIdManager.cs
+++ b/Source/SvgElementIdManager.cs
@@ -153,15 +153,6 @@ namespace Svg
                 return id;
             }
 
-            if (char.IsDigit(id[0]))
-            {
-                if (autoForceUniqueID)
-                {
-                    return EnsureValidId("id" + id, true);
-                }
-                throw new SvgIDWrongFormatException("ID cannot start with a digit: '" + id + "'.");
-            }
-
             if (this._idValueMap.ContainsKey(id))
             {
                 if (autoForceUniqueID)

--- a/Source/SvgElementIdManager.cs
+++ b/Source/SvgElementIdManager.cs
@@ -137,12 +137,11 @@ namespace Svg
         }
 
         /// <summary>
-        /// Ensures that the specified ID is valid within the containing <see cref="SvgDocument"/>.
+        /// Ensures that the specified ID is unique within the containing <see cref="SvgDocument"/>.
         /// </summary>
         /// <param name="id">A <see cref="string"/> containing the ID to validate.</param>
         /// <param name="autoForceUniqueID">Creates a new unique id <see cref="string"/>.</param>
         /// <exception cref="SvgException">
-        /// <para>The ID cannot start with a digit.</para>
         /// <para>An element with the same ID already exists within the containing <see cref="SvgDocument"/>.</para>
         /// </exception>
         public string EnsureValidId(string id, bool autoForceUniqueID = false)


### PR DESCRIPTION
According to W3C, an id name cannot start with a full stop (.) character, and a hyphen-minus (-) character, too.
But check only number.

So simply delete number check.