### PR TITLE
Bug fix for issue #473 : SvgText wrong position in some scenario

### DIFF
--- a/Source/Basic Shapes/SvgVisualElement.cs
+++ b/Source/Basic Shapes/SvgVisualElement.cs
@@ -288,7 +288,7 @@ namespace Svg
                                     }
 
                                     /* divide by stroke width - GDI behaviour that I don't quite understand yet.*/
-                                    pen.DashPattern = this.StrokeDashArray.ConvertAll(u => ((u.ToDeviceValue(renderer, UnitRenderingType.Other, this) <= 0) ? 1 : u.ToDeviceValue(renderer, UnitRenderingType.Other, this)) /
+                                    pen.DashPattern = this.StrokeDashArray.Select(u => ((u.ToDeviceValue(renderer, UnitRenderingType.Other, this) <= 0) ? 1 : u.ToDeviceValue(renderer, UnitRenderingType.Other, this)) /
                                         ((strokeWidth <= 0) ? 1 : strokeWidth)).ToArray();
 
                                     if (this.StrokeLineCap == SvgStrokeLineCap.Round)

--- a/Source/DataTypes/SvgUnitCollection.cs
+++ b/Source/DataTypes/SvgUnitCollection.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
@@ -10,8 +11,18 @@ namespace Svg
     /// Represents a list of <see cref="SvgUnit"/>.
     /// </summary>
     [TypeConverter(typeof(SvgUnitCollectionConverter))]
-    public class SvgUnitCollection : List<SvgUnit>
+    public class SvgUnitCollection : ObservableCollection<SvgUnit>
     {
+        public void AddRange(IEnumerable<SvgUnit> collection)
+        {
+            if (collection == null) { throw new ArgumentNullException(nameof(collection)); }
+
+            foreach(SvgUnit unit in collection)
+            {
+                this.Add(unit);
+            }
+        }
+
         public override string ToString()
         {
             // The correct separator should be a single white space.

--- a/Source/Svg.csproj
+++ b/Source/Svg.csproj
@@ -90,7 +90,7 @@ NetStandard does not fully support the Drawing2D package - so has been left out.
     <Reference Include="System.Drawing" />
     <Reference Include="System.Web" />
     <Reference Include="System.Xml" />
-	<Reference Include="WindowsBase" />
+    <Reference Include="WindowsBase" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net40'">

--- a/Source/Svg.csproj
+++ b/Source/Svg.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;net35</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.2;net35;net452;net472</TargetFrameworks>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RootNamespace>Svg</RootNamespace>
     <AssemblyName>Svg</AssemblyName>
@@ -37,6 +37,7 @@ Supports multiple targets v3.5 thru to dotnetcore2.2.
 NetStandard does not fully support the Drawing2D package - so has been left out.
     </PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/vvvv/SVG</PackageProjectUrl>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
 
   <ItemGroup>
@@ -87,8 +88,9 @@ NetStandard does not fully support the Drawing2D package - so has been left out.
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Web"/>
-    <Reference Include="System.Xml"/>
+    <Reference Include="System.Web" />
+    <Reference Include="System.Xml" />
+	<Reference Include="WindowsBase" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net40'">
@@ -96,8 +98,8 @@ NetStandard does not fully support the Drawing2D package - so has been left out.
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Web"/>
-    <Reference Include="System.Xml"/>
+    <Reference Include="System.Web" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net452'">
@@ -105,8 +107,8 @@ NetStandard does not fully support the Drawing2D package - so has been left out.
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Web"/>
-    <Reference Include="System.Xml"/>
+    <Reference Include="System.Web" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net472'">
@@ -114,13 +116,16 @@ NetStandard does not fully support the Drawing2D package - so has been left out.
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Web"/>
-    <Reference Include="System.Xml"/>
+    <Reference Include="System.Web" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.2'">
     <PackageReference Include="System.Drawing.Common">
       <Version>4.5.1</Version>
+    </PackageReference>
+    <PackageReference Include="System.ObjectModel">
+      <Version>4.3.0</Version>
     </PackageReference>
   </ItemGroup>
 

--- a/Source/Text/SvgTextBase.cs
+++ b/Source/Text/SvgTextBase.cs
@@ -145,11 +145,11 @@ namespace Svg
             this.IsPathDirty = true;
         }
 
-		/// <summary>
-		/// Gets or sets the rotate.
-		/// </summary>
-		/// <value>The rotate.</value>
-		[SvgAttribute("rotate")]
+        /// <summary>
+        /// Gets or sets the rotate.
+        /// </summary>
+        /// <value>The rotate.</value>
+        [SvgAttribute("rotate")]
         public virtual string Rotate
         {
             get { return this._rotate; }

--- a/Source/Text/SvgTextBase.cs
+++ b/Source/Text/SvgTextBase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Globalization;
@@ -11,12 +12,20 @@ namespace Svg
 {
     public abstract class SvgTextBase : SvgVisualElement
     {
-        [CLSCompliant(false)] protected SvgUnitCollection _x = new SvgUnitCollection();
-        [CLSCompliant(false)] protected SvgUnitCollection _y = new SvgUnitCollection();
-        [CLSCompliant(false)] protected SvgUnitCollection _dy = new SvgUnitCollection();
-        [CLSCompliant(false)] protected SvgUnitCollection _dx = new SvgUnitCollection();
+        [CLSCompliant(false)] private SvgUnitCollection _x = new SvgUnitCollection();
+        [CLSCompliant(false)] private SvgUnitCollection _y = new SvgUnitCollection();
+        [CLSCompliant(false)] private SvgUnitCollection _dy = new SvgUnitCollection();
+        [CLSCompliant(false)] private SvgUnitCollection _dx = new SvgUnitCollection();
         private string _rotate;
         private List<float> _rotations = new List<float>();
+
+        public SvgTextBase()
+        {
+            _x.CollectionChanged += OnCoordinateChanged;
+            _dx.CollectionChanged += OnCoordinateChanged;
+            _y.CollectionChanged += OnCoordinateChanged;
+            _dy.CollectionChanged += OnCoordinateChanged;
+        }
 
         /// <summary>
         /// Gets or sets the text to be rendered.
@@ -55,7 +64,10 @@ namespace Svg
             {
                 if (_x != value)
                 {
+                    if (_x != null) { _x.CollectionChanged -= OnCoordinateChanged; }
                     this._x = value;
+                    if (_x != null) { _x.CollectionChanged += OnCoordinateChanged; }
+
                     this.IsPathDirty = true;
                     OnAttributeChanged(new AttributeEventArgs { Attribute = "x", Value = value });
                 }
@@ -74,7 +86,10 @@ namespace Svg
             {
                 if (_dx != value)
                 {
+                    if (_dx != null) { _dx.CollectionChanged -= OnCoordinateChanged; }
                     this._dx = value;
+                    if (_dx != null) { _dx.CollectionChanged += OnCoordinateChanged; }
+
                     this.IsPathDirty = true;
                     OnAttributeChanged(new AttributeEventArgs { Attribute = "dx", Value = value });
                 }
@@ -93,7 +108,10 @@ namespace Svg
             {
                 if (_y != value)
                 {
+                    if (_y != null) { _y.CollectionChanged -= OnCoordinateChanged; } 
                     this._y = value;
+                    if (_y != null) { _y.CollectionChanged += OnCoordinateChanged; }
+
                     this.IsPathDirty = true;
                     OnAttributeChanged(new AttributeEventArgs { Attribute = "y", Value = value });
                 }
@@ -112,18 +130,26 @@ namespace Svg
             {
                 if (_dy != value)
                 {
+                    if (_dy != null) { _dy.CollectionChanged -= OnCoordinateChanged; }
                     this._dy = value;
+                    if (_dy != null) { _dy.CollectionChanged += OnCoordinateChanged; }
+
                     this.IsPathDirty = true;
                     OnAttributeChanged(new AttributeEventArgs { Attribute = "dy", Value = value });
                 }
             }
         }
 
-        /// <summary>
-        /// Gets or sets the rotate.
-        /// </summary>
-        /// <value>The rotate.</value>
-        [SvgAttribute("rotate")]
+        private void OnCoordinateChanged(object sender, NotifyCollectionChangedEventArgs args)
+        {
+            this.IsPathDirty = true;
+        }
+
+		/// <summary>
+		/// Gets or sets the rotate.
+		/// </summary>
+		/// <value>The rotate.</value>
+		[SvgAttribute("rotate")]
         public virtual string Rotate
         {
             get { return this._rotate; }

--- a/Source/Text/SvgTextPath.cs
+++ b/Source/Text/SvgTextPath.cs
@@ -25,16 +25,16 @@ namespace Svg
         [SvgAttribute("startOffset")]
         public virtual SvgUnit StartOffset
         {
-            get { return (_dx.Count < 1 ? SvgUnit.None : _dx[0]); }
+            get { return (base.Dx.Count < 1 ? SvgUnit.None : base.Dx[0]); }
             set
             {
-                if (_dx.Count < 1)
+                if (base.Dx.Count < 1)
                 {
-                    _dx.Add(value);
+                    base.Dx.Add(value);
                 }
                 else
                 {
-                    _dx[0] = value;
+                    base.Dx[0] = value;
                 }
             }
         }

--- a/Tests/Svg.UnitTests/SvgTextTests.cs
+++ b/Tests/Svg.UnitTests/SvgTextTests.cs
@@ -28,5 +28,25 @@ namespace Svg.UnitTests
                 Assert.AreEqual("test1", xmlDoc.DocumentElement.FirstChild.InnerText);
             }
         }
+
+        /// <summary>
+        /// Test related to bug #473.
+        /// We check if changing a coordinate invalidate the cache.
+        /// We doing this indirectly by checking the Bound property, which uses the cache.
+        /// The Bound coordinates must be updated after adding a X and a Y
+        /// </summary>
+        [TestMethod]
+        public void ChangingCoordinatesInvalidatePathCache()
+        {
+            SvgText text = new SvgText();
+            text.Text = "Test invalidate cache";
+            float origX = text.Bounds.X;
+            float origY = text.Bounds.Y;
+            text.X.Add(100);
+            text.Y.Add(100);
+
+            Assert.AreNotEqual(origX, text.Bounds.X);
+            Assert.AreNotEqual(origY, text.Bounds.Y);
+        }
     }
 }


### PR DESCRIPTION
Pull request for fix the bug #473.

I proceed by changing the base class of `SvgUnitCollection` from `List<SvgUnit>` to `ObservableCollection<SvgUnit>`. I made the needed changes and wrote a unit test.

This PR may cause some compatibility issue if methods specific to List were used (like AddRange, but I provided an implementation to minimize the impact).

I had to add a reference to an assembly:
- WindowsBase.dll for Net35
- Nuget package "System.ObjectModel" for other targets

I do not test each target platform (I do not know how to do it), but unit test and SvgW3CTestRunner run without any problem.