### PR TITLE
Add net462 build target

### DIFF
--- a/Source/Svg.csproj
+++ b/Source/Svg.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;net35;net452;net472</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.2;net35;net452;net462;net472</TargetFrameworks>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RootNamespace>Svg</RootNamespace>
     <AssemblyName>Svg</AssemblyName>
@@ -72,6 +72,12 @@ NetStandard does not fully support the Drawing2D package - so has been left out.
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)'=='net462'">
+    <Title>Svg for .Net Framework 4.6.2</Title>
+    <DefineConstants>$(DefineConstants);NETFULL;NET462</DefineConstants>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(TargetFramework)'=='net472'">
     <Title>Svg for .Net Framework 4.7.2</Title>
     <DefineConstants>$(DefineConstants);NETFULL;NET472</DefineConstants>
@@ -103,6 +109,15 @@ NetStandard does not fully support the Drawing2D package - so has been left out.
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net452'">
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='net462'">
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />

--- a/Source/Web/SvgHandler.cs
+++ b/Source/Web/SvgHandler.cs
@@ -1,4 +1,4 @@
-#if NET35 || NET40 || NET452 || NET472
+#if NET35 || NET40 || NET452 || NET462 || NET472
 using System;
 using System.Collections;
 using System.Collections.Generic;


### PR DESCRIPTION
To package (and publish) a .NET desktop app to the Microsoft Store via the "Desktop Bridge", the app must target .NET 4.6.2 or later.

See: https://docs.microsoft.com/en-us/windows/msix/desktop/desktop-to-uwp-prepare

This change adds the net462 build target, for app developers who need to target that minimum version.