### PR TITLE
Fix: #315 'Crash on hover class - and wrong colors' issue.

### DIFF
--- a/Source/SvgDocument.cs
+++ b/Source/SvgDocument.cs
@@ -392,13 +392,20 @@ namespace Svg
 
                     foreach (var selector in selectors)
                     {
-                        elemsToStyle = svgDocument.QuerySelectorAll(rule.Selector.ToString(), elementFactory);
-                        foreach (var elem in elemsToStyle)
+                        try
                         {
-                            foreach (var decl in rule.Declarations)
+                            elemsToStyle = svgDocument.QuerySelectorAll(rule.Selector.ToString(), elementFactory);
+                            foreach (var elem in elemsToStyle)
                             {
-                                elem.AddStyle(decl.Name, decl.Term.ToString(), rule.Selector.GetSpecificity());
+                                foreach (var decl in rule.Declarations)
+                                {
+                                    elem.AddStyle(decl.Name, decl.Term.ToString(), rule.Selector.GetSpecificity());
+                                }
                             }
+                        }
+                        catch (Exception ex)
+                        {
+                            Trace.TraceWarning(ex.Message);
                         }
                     }
                 }


### PR DESCRIPTION
No one was catching when an exception occurred with Pseudo-Class that is not supported by Fizzler like hover.
Change to catch and ignore.

[This patch](https://github.com/atifaziz/Fizzler/issues/49) has the same effect as not specifying Pseudo-Class.(`hover` style is applied.)
So I think that can not use this issue.

It is necessary to check the rendering of `<path>` for cause of the slightly different result image !