### PR TITLE
Omit xml:space if not needed, while writing back SVG files.

### DIFF
--- a/Source/Document Structure/SvgFragment.cs
+++ b/Source/Document Structure/SvgFragment.cs
@@ -150,7 +150,7 @@ namespace Svg
 
         public override XmlSpaceHandling SpaceHandling
         {
-            get { return GetAttribute("space", false, XmlSpaceHandling.@default); }
+            get { return GetAttribute("space", Inherited, XmlSpaceHandling.@default); }
             set { base.SpaceHandling = value; this.IsPathDirty = true; }
         }
 

--- a/Source/Document Structure/SvgFragment.cs
+++ b/Source/Document Structure/SvgFragment.cs
@@ -148,6 +148,12 @@ namespace Svg
             set { this.Attributes["font-family"] = value; }
         }
 
+        public override XmlSpaceHandling SpaceHandling
+        {
+            get { return GetAttribute("space", false, XmlSpaceHandling.@default); }
+            set { base.SpaceHandling = value; this.IsPathDirty = true; }
+        }
+
         /// <summary>
         /// Applies the required transforms to <see cref="ISvgRenderer"/>.
         /// </summary>

--- a/Source/SvgAttributeAttribute.cs
+++ b/Source/SvgAttributeAttribute.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.ComponentModel;
 
 namespace Svg
 {
@@ -10,7 +8,7 @@ namespace Svg
     /// Specifies the SVG attribute name of the associated property.
     /// </summary>
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Event)]
-    public class SvgAttributeAttribute : System.Attribute
+    public class SvgAttributeAttribute : Attribute
     {
         /// <summary>
         /// Gets a <see cref="string"/> containing the XLink namespace (http://www.w3.org/1999/xlink).
@@ -18,47 +16,33 @@ namespace Svg
         public const string SvgNamespace = "http://www.w3.org/2000/svg";
         public const string XLinkPrefix = "xlink";
         public const string XLinkNamespace = "http://www.w3.org/1999/xlink";
+        public const string XmlPrefix = "xml";
         public const string XmlNamespace = "http://www.w3.org/XML/1998/namespace";
 
         public static readonly List<KeyValuePair<string, string>> Namespaces = new List<KeyValuePair<string, string>>()
                                                                             {
-                                                                                new KeyValuePair<string, string>("", SvgNamespace),
+                                                                                new KeyValuePair<string, string>(string.Empty, SvgNamespace),
                                                                                 new KeyValuePair<string, string>(XLinkPrefix, XLinkNamespace),
-                                                                                new KeyValuePair<string, string>("xml", XmlNamespace)
+                                                                                new KeyValuePair<string, string>(XmlPrefix, XmlNamespace)
                                                                             };
-        private bool _inAttrDictionary;
-        private string _name;
-        private string _namespace;
 
         public override bool Equals(object obj)
         {
-            return Match(obj);
+            if (!(obj is SvgAttributeAttribute))
+                return false;
+
+            var indicator = (SvgAttributeAttribute)obj;
+
+            // Always match if either value is string.Empty (wildcard)
+            if (indicator.Name == string.Empty)
+                return false;
+
+            return string.Equals(Name, indicator.Name);
         }
 
         public override int GetHashCode()
         {
             return base.GetHashCode();
-        }
-
-        /// <summary>
-        /// When overridden in a derived class, returns a value that indicates whether this instance equals a specified object.
-        /// </summary>
-        /// <param name="obj">An <see cref="T:System.Object"/> to compare with this instance of <see cref="T:System.Attribute"/>.</param>
-        /// <returns>
-        /// true if this instance equals <paramref name="obj"/>; otherwise, false.
-        /// </returns>
-        public override bool Match(object obj)
-        {
-            SvgAttributeAttribute indicator = obj as SvgAttributeAttribute;
-
-            if (indicator == null)
-                return false;
-
-            // Always match if either value is String.Empty (wildcard)
-            if (indicator.Name == String.Empty)
-                return false;
-
-            return String.Compare(indicator.Name, this.Name) == 0;
         }
 
         /// <summary>
@@ -68,40 +52,30 @@ namespace Svg
         {
             get
             {
-                if (_namespace == SvgNamespace)
-                    return _name;
-                return Namespaces.First(x => x.Value == _namespace).Key + ":" + _name;
+                if (NameSpace == SvgNamespace)
+                    return Name;
+                return Namespaces.First(x => x.Value == NameSpace).Key + ":" + Name;
             }
         }
-
 
         /// <summary>
         /// Gets the name of the SVG attribute.
         /// </summary>
-        public string Name
-        {
-            get { return this._name; }
-        }
+        public string Name { get; private set; }
 
         /// <summary>
         /// Gets the namespace of the SVG attribute.
         /// </summary>
-        public string NameSpace
-        {
-            get { return this._namespace; }
-        }
+        public string NameSpace { get; private set; }
 
-        public bool InAttributeDictionary
-        {
-            get { return this._inAttrDictionary; }
-        }
+        public bool InAttributeDictionary { get; private set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SvgAttributeAttribute"/> class.
         /// </summary>
         internal SvgAttributeAttribute()
         {
-            this._name = String.Empty;
+            Name = string.Empty;
         }
 
         /// <summary>
@@ -110,15 +84,15 @@ namespace Svg
         /// <param name="name">The name of the SVG attribute.</param>
         internal SvgAttributeAttribute(string name)
         {
-            this._name = name;
-            this._namespace = SvgNamespace;
+            Name = name;
+            NameSpace = SvgNamespace;
         }
 
         internal SvgAttributeAttribute(string name, bool inAttrDictionary)
         {
-            this._name = name;
-            this._namespace = SvgNamespace;
-            this._inAttrDictionary = inAttrDictionary;
+            Name = name;
+            NameSpace = SvgNamespace;
+            InAttributeDictionary = inAttrDictionary;
         }
 
         /// <summary>
@@ -128,8 +102,8 @@ namespace Svg
         /// <param name="nameSpace">The namespace of the SVG attribute (e.g. http://www.w3.org/2000/svg).</param>
         public SvgAttributeAttribute(string name, string nameSpace)
         {
-            this._name = name;
-            this._namespace = nameSpace;
+            Name = name;
+            NameSpace = nameSpace;
         }
     }
 }

--- a/Source/SvgAttributeCollection.cs
+++ b/Source/SvgAttributeCollection.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Svg
 {
@@ -11,7 +8,7 @@ namespace Svg
     /// </summary>
     public sealed class SvgAttributeCollection : Dictionary<string, object>
     {
-        private SvgElement _owner;
+        private readonly SvgElement _owner;
 
         /// <summary>
         /// Initialises a new instance of a <see cref="SvgAttributeCollection"/> with the given <see cref="SvgElement"/> as the owner.
@@ -19,7 +16,7 @@ namespace Svg
         /// <param name="owner">The <see cref="SvgElement"/> owner of the collection.</param>
         public SvgAttributeCollection(SvgElement owner)
         {
-            this._owner = owner;
+            _owner = owner;
         }
 
         /// <summary>
@@ -27,30 +24,12 @@ namespace Svg
         /// </summary>
         /// <typeparam name="TAttributeType">The type of the attribute value.</typeparam>
         /// <param name="attributeName">A <see cref="string"/> containing the name of the attribute.</param>
-        /// <returns>The attribute value if available; otherwise the default value of <typeparamref name="TAttributeType"/>.</returns>
-        public TAttributeType GetAttribute<TAttributeType>(string attributeName)
-        {
-            if (this.ContainsKey(attributeName) && base[attributeName] != null)
-            {
-                return (TAttributeType)base[attributeName];
-            }
-
-            return this.GetAttribute<TAttributeType>(attributeName, default(TAttributeType));
-        }
-
-        /// <summary>
-        /// Gets the attribute with the specified name.
-        /// </summary>
-        /// <typeparam name="T">The type of the attribute value.</typeparam>
-        /// <param name="attributeName">A <see cref="string"/> containing the name of the attribute.</param>
         /// <param name="defaultValue">The value to return if a value hasn't already been specified.</param>
-        /// <returns>The attribute value if available; otherwise the default value of <typeparamref name="T"/>.</returns>
-        public T GetAttribute<T>(string attributeName, T defaultValue)
+        /// <returns>The attribute value if available; otherwise the default value of <typeparamref name="TAttributeType"/>.</returns>
+        public TAttributeType GetAttribute<TAttributeType>(string attributeName, TAttributeType defaultValue = default(TAttributeType))
         {
-            if (this.ContainsKey(attributeName) && base[attributeName] != null)
-            {
-                return (T)base[attributeName];
-            }
+            if (ContainsKey(attributeName) && base[attributeName] != null)
+                return (TAttributeType)base[attributeName];
 
             return defaultValue;
         }
@@ -60,10 +39,11 @@ namespace Svg
         /// </summary>
         /// <typeparam name="TAttributeType">The type of the attribute value.</typeparam>
         /// <param name="attributeName">A <see cref="string"/> containing the name of the attribute.</param>
+        /// <param name="defaultValue">The value to return if a value hasn't already been specified.</param>
         /// <returns>The attribute value if available; otherwise the ancestors value for the same attribute; otherwise the default value of <typeparamref name="TAttributeType"/>.</returns>
-        public TAttributeType GetInheritedAttribute<TAttributeType>(string attributeName)
+        public TAttributeType GetInheritedAttribute<TAttributeType>(string attributeName, TAttributeType defaultValue = default(TAttributeType))
         {
-            if (this.ContainsKey(attributeName) && !IsInheritValue(base[attributeName]))
+            if (ContainsKey(attributeName) && !IsInheritValue(base[attributeName]))
             {
                 var result = (TAttributeType)base[attributeName];
                 var deferred = result as SvgDeferredPaintServer;
@@ -71,16 +51,8 @@ namespace Svg
                 return result;
             }
 
-            if (this._owner.Parent != null)
-            {
-                var parentAttribute = this._owner.Parent.Attributes[attributeName];
-                if (parentAttribute != null)
-                {
-                    return (TAttributeType)parentAttribute;
-                }
-            }
-
-            return default(TAttributeType);
+            var parentAttribute = _owner.Parent?.Attributes[attributeName];
+            return parentAttribute != null ? (TAttributeType)parentAttribute : defaultValue;
         }
 
         private bool IsInheritValue(object value)
@@ -107,10 +79,10 @@ namespace Svg
         /// <returns>The attribute value associated with the specified name; If there is no attribute the parent's value will be inherited.</returns>
         public new object this[string attributeName]
         {
-            get { return this.GetInheritedAttribute<object>(attributeName); }
+            get { return GetInheritedAttribute<object>(attributeName); }
             set
             {
-                if (base.ContainsKey(attributeName))
+                if (ContainsKey(attributeName))
                 {
                     var oldVal = base[attributeName];
                     if (TryUnboxedCheck(oldVal, value))
@@ -145,9 +117,7 @@ namespace Svg
                     return true;
             }
             else
-            {
                 return a != b;
-            }
         }
 
         private bool UnboxAndCheck<T>(object a, object b)
@@ -169,19 +139,16 @@ namespace Svg
         {
             var handler = AttributeChanged;
             if (handler != null)
-            {
-                handler(this._owner, new AttributeEventArgs { Attribute = attribute, Value = value });
-            }
+                handler(_owner, new AttributeEventArgs { Attribute = attribute, Value = value });
         }
     }
-
 
     /// <summary>
     /// A collection of Custom Attributes
     /// </summary>
     public sealed class SvgCustomAttributeCollection : Dictionary<string, string>
     {
-        private SvgElement _owner;
+        private readonly SvgElement _owner;
 
         /// <summary>
         /// Initialises a new instance of a <see cref="SvgAttributeCollection"/> with the given <see cref="SvgElement"/> as the owner.
@@ -189,7 +156,7 @@ namespace Svg
         /// <param name="owner">The <see cref="SvgElement"/> owner of the collection.</param>
         public SvgCustomAttributeCollection(SvgElement owner)
         {
-            this._owner = owner;
+            _owner = owner;
         }
 
         /// <summary>
@@ -202,7 +169,7 @@ namespace Svg
             get { return base[attributeName]; }
             set
             {
-                if (base.ContainsKey(attributeName))
+                if (ContainsKey(attributeName))
                 {
                     var oldVal = base[attributeName];
                     base[attributeName] = value;
@@ -225,9 +192,7 @@ namespace Svg
         {
             var handler = AttributeChanged;
             if (handler != null)
-            {
-                handler(this._owner, new AttributeEventArgs { Attribute = attribute, Value = value });
-            }
+                handler(_owner, new AttributeEventArgs { Attribute = attribute, Value = value });
         }
     }
 }

--- a/Source/SvgDefinitionDefaults.cs
+++ b/Source/SvgDefinitionDefaults.cs
@@ -15,6 +15,9 @@ namespace Svg
                 { { "cx", "50%" }, { "cy", "50%" }, { "r", "50%" } } },
                 { "SvgLinearGradientServer", new Dictionary<string, string>
                 { { "x1", "0%" }, { "x2", "100%" }, { "y1", "0%" }, { "y2", "100%" } } },
+
+                { "SvgFragment", new Dictionary<string, string>
+                { { "space", "default" } } },
             };
 
         // common defaults
@@ -65,6 +68,8 @@ namespace Svg
                 { "markerWidth", "3" },
                 { "markerHeight", "3" },
                 { "orient", "0" },
+
+                { "space", "inherit" },
             };
 
         /// <summary>

--- a/Source/SvgDefinitionDefaults.cs
+++ b/Source/SvgDefinitionDefaults.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace Svg
 {
@@ -11,18 +8,18 @@ namespace Svg
     public static class SvgDefaults
     {
         // defaults that are specific to some elements
-        private static Dictionary<string, Dictionary<string, string>> _propDefaults =
+        private static readonly Dictionary<string, Dictionary<string, string>> _propDefaults =
             new Dictionary<string, Dictionary<string, string>>
             {
                 { "SvgRadialGradientServer", new Dictionary<string, string>
                 { { "cx", "50%" }, { "cy", "50%" }, { "r", "50%" } } },
                 { "SvgLinearGradientServer", new Dictionary<string, string>
-                { { "x1", "0%" }, { "x2", "100%" }, { "y1", "0%" }, { "y2", "100%" }  } },
+                { { "x1", "0%" }, { "x2", "100%" }, { "y1", "0%" }, { "y2", "100%" } } },
             };
 
         // common defaults
         private static readonly Dictionary<string, string> _defaults =
-            new Dictionary<string, string>()
+            new Dictionary<string, string>
             {
                 { "d", "" },
                 { "viewBox", "0, 0, 0, 0" },
@@ -67,13 +64,8 @@ namespace Svg
                 { "refY", "0" },
                 { "markerWidth", "3" },
                 { "markerHeight", "3" },
-                { "orient", "0" }
+                { "orient", "0" },
             };
-
-
-        static SvgDefaults()
-        {
-        }
 
         /// <summary>
         /// Checks whether the property value is the default value of the svg definition.
@@ -83,18 +75,12 @@ namespace Svg
         /// <param name="value">.NET value of the attribute</param>
         public static bool IsDefault(string attributeName, string componentType, string value)
         {
-            if (_propDefaults.ContainsKey(componentType))
-            {
-                if (_propDefaults[componentType].ContainsKey(attributeName))
-                {
-                    return _propDefaults[componentType][attributeName] == value;
-                }
-            }
+            if (_propDefaults.ContainsKey(componentType) && _propDefaults[componentType].ContainsKey(attributeName))
+                return _propDefaults[componentType][attributeName] == value;
 
             if (_defaults.ContainsKey(attributeName))
-            {
                 return _defaults[attributeName] == value;
-            }
+
             return false;
         }
     }

--- a/Source/SvgElement.cs
+++ b/Source/SvgElement.cs
@@ -287,9 +287,9 @@ namespace Svg
         protected internal TAttributeType GetAttribute<TAttributeType>(string attributeName, bool inherit, TAttributeType defaultValue = default(TAttributeType))
         {
             if (inherit)
-                return Attributes.GetInheritedAttribute<TAttributeType>(attributeName, defaultValue);
+                return Attributes.GetInheritedAttribute(attributeName, defaultValue);
             else
-                return Attributes.GetAttribute<TAttributeType>(attributeName, defaultValue);
+                return Attributes.GetAttribute(attributeName, defaultValue);
         }
 
         /// <summary>

--- a/Source/SvgElement.cs
+++ b/Source/SvgElement.cs
@@ -282,6 +282,16 @@ namespace Svg
             }
         }
 
+        protected bool Inherited { get; set; } = true;
+
+        protected internal TAttributeType GetAttribute<TAttributeType>(string attributeName, bool inherit, TAttributeType defaultValue = default(TAttributeType))
+        {
+            if (inherit)
+                return Attributes.GetInheritedAttribute<TAttributeType>(attributeName, defaultValue);
+            else
+                return Attributes.GetAttribute<TAttributeType>(attributeName, defaultValue);
+        }
+
         /// <summary>
         /// Gets a collection of custom attributes
         /// </summary>
@@ -407,8 +417,8 @@ namespace Svg
         [SvgAttribute("space", SvgAttributeAttribute.XmlNamespace)]
         public virtual XmlSpaceHandling SpaceHandling
         {
-            get { return (this.Attributes["space"] == null) ? XmlSpaceHandling.@default : (XmlSpaceHandling)this.Attributes["space"]; }
-            set { this.Attributes["space"] = value; }
+            get { return GetAttribute("space", Inherited, XmlSpaceHandling.inherit); }
+            set { Attributes["space"] = value; }
         }
 
         public void SetAndForceUniqueID(string value, bool autoForceUniqueID = true, Action<SvgElement, string, string> logElementOldIDNewID = null)
@@ -609,65 +619,81 @@ namespace Svg
             var opacityAttributes = new List<PropertyAttributeTuple>();
             var opacityValues = new Dictionary<string, float>();
 
-            foreach (var attr in _svgPropertyAttributes)
+            try
             {
-                if (attr.Property.Converter.CanConvertTo(typeof(string)))
+                Inherited = false;
+
+                foreach (var attr in _svgPropertyAttributes)
                 {
-                    if (attr.Attribute.Name == "fill-opacity" || attr.Attribute.Name == "stroke-opacity")
+                    if (attr.Property.Converter.CanConvertTo(typeof(string)))
                     {
-                        opacityAttributes.Add(attr);
-                        continue;
-                    }
-
-                    if (!attr.Attribute.InAttributeDictionary || _attributes.ContainsKey(attr.Attribute.Name))
-                    {
-                        var propertyValue = attr.Property.GetValue(this);
-
-                        var forceWrite = false;
-                        var writeStyle = attr.Attribute.Name == "fill" || attr.Attribute.Name == "stroke";
-
-                        if (writeStyle && (Parent != null))
+                        if (attr.Attribute.Name == "fill-opacity" || attr.Attribute.Name == "stroke-opacity")
                         {
-                            if (propertyValue == SvgColourServer.NotSet) continue;
-
-                            object parentValue;
-                            if (TryResolveParentAttributeValue(attr.Attribute.Name, out parentValue))
-                            {
-                                if ((parentValue == propertyValue)
-                                    || ((parentValue != null) && parentValue.Equals(propertyValue)))
-                                    continue;
-
-                                forceWrite = true;
-                            }
+                            opacityAttributes.Add(attr);
+                            continue;
                         }
 
-                        var hasOpacity = writeStyle;
-                        if (hasOpacity)
+                        if (!attr.Attribute.InAttributeDictionary || _attributes.ContainsKey(attr.Attribute.Name))
                         {
-                            if (propertyValue is SvgColourServer && ((SvgColourServer)propertyValue).Colour.A < 255)
+                            var propertyValue = attr.Property.GetValue(this);
+
+                            var forceWrite = false;
+                            var writeStyle = attr.Attribute.Name == "fill" || attr.Attribute.Name == "stroke";
+
+                            if (writeStyle && (Parent != null))
                             {
-                                var opacity = ((SvgColourServer)propertyValue).Colour.A / 255f;
-                                opacityValues.Add(attr.Attribute.Name + "-opacity", opacity);
+                                if (propertyValue == SvgColourServer.NotSet) continue;
+
+                                object parentValue;
+                                if (TryResolveParentAttributeValue(attr.Attribute.Name, out parentValue))
+                                {
+                                    if ((parentValue == propertyValue)
+                                        || ((parentValue != null) && parentValue.Equals(propertyValue)))
+                                        continue;
+
+                                    forceWrite = true;
+                                }
                             }
-                        }
+
+                            var hasOpacity = writeStyle;
+                            if (hasOpacity)
+                            {
+                                if (propertyValue is SvgColourServer && ((SvgColourServer)propertyValue).Colour.A < 255)
+                                {
+                                    var opacity = ((SvgColourServer)propertyValue).Colour.A / 255f;
+                                    opacityValues.Add(attr.Attribute.Name + "-opacity", opacity);
+                                }
+                            }
 
 #if NETFULL
-                        var value = (string)attr.Property.Converter.ConvertTo(propertyValue, typeof(string));
+                            var value = (string)attr.Property.Converter.ConvertTo(propertyValue, typeof(string));
 #else
-                        // dotnetcore throws exception if input is null
-                        var value = propertyValue == null ? null : (string)attr.Property.Converter.ConvertTo(propertyValue, typeof(string));
+                            // dotnetcore throws exception if input is null
+                            var value = propertyValue == null ? null : (string)attr.Property.Converter.ConvertTo(propertyValue, typeof(string));
 #endif
 
-                        if (propertyValue != null)
-                        {
-                            if (!string.IsNullOrEmpty(value))
+                            if (propertyValue != null)
                             {
-                                if (attr.Attribute.NamespaceAndName == "xlink:href" && value.StartsWith("url("))
-                                    value = new StringBuilder(value).Remove(value.Length - 1, 1).Remove(0, 4).ToString();
-                            }
+                                if (!string.IsNullOrEmpty(value))
+                                {
+                                    if (attr.Attribute.NamespaceAndName == "xlink:href" && value.StartsWith("url("))
+                                        value = new StringBuilder(value).Remove(value.Length - 1, 1).Remove(0, 4).ToString();
+                                }
 
-                            //Only write the attribute's value if it is not the default value, not null/empty, or we're forcing the write.
-                            if (forceWrite || (!string.IsNullOrEmpty(value) && !SvgDefaults.IsDefault(attr.Attribute.Name, attr.Property.ComponentType.Name, value)))
+                                //Only write the attribute's value if it is not the default value, not null/empty, or we're forcing the write.
+                                if (forceWrite || (!string.IsNullOrEmpty(value) && !SvgDefaults.IsDefault(attr.Attribute.Name, attr.Property.ComponentType.Name, value)))
+                                {
+                                    if (writeStyle)
+                                    {
+                                        styles[attr.Attribute.Name] = value;
+                                    }
+                                    else
+                                    {
+                                        writer.WriteAttributeString(attr.Attribute.NamespaceAndName, value);
+                                    }
+                                }
+                            }
+                            else if (attr.Attribute.Name == "fill") //if fill equals null, write 'none'
                             {
                                 if (writeStyle)
                                 {
@@ -679,44 +705,37 @@ namespace Svg
                                 }
                             }
                         }
-                        else if (attr.Attribute.Name == "fill") //if fill equals null, write 'none'
-                        {
-                            if (writeStyle)
-                            {
-                                styles[attr.Attribute.Name] = value;
-                            }
-                            else
-                            {
-                                writer.WriteAttributeString(attr.Attribute.NamespaceAndName, value);
-                            }
-                        }
+                    }
+                }
+
+                foreach (var attr in opacityAttributes)
+                {
+                    var opacity = 1f;
+                    var write = false;
+
+                    var key = attr.Attribute.Name;
+                    if (opacityValues.ContainsKey(key))
+                    {
+                        opacity = opacityValues[key];
+                        write = true;
+                    }
+                    if (!attr.Attribute.InAttributeDictionary || _attributes.ContainsKey(key))
+                    {
+                        opacity *= (float)attr.Property.GetValue(this);
+                        write = true;
+                    }
+                    if (write)
+                    {
+                        opacity = (float)Math.Round(opacity, 2, MidpointRounding.AwayFromZero);
+                        var value = (string)attr.Property.Converter.ConvertTo(opacity, typeof(string));
+                        if (!string.IsNullOrEmpty(value) && !SvgDefaults.IsDefault(attr.Attribute.Name, attr.Property.ComponentType.Name, value))
+                            writer.WriteAttributeString(attr.Attribute.NamespaceAndName, value);
                     }
                 }
             }
-
-            foreach (var attr in opacityAttributes)
+            finally
             {
-                var opacity = 1f;
-                var write = false;
-
-                var key = attr.Attribute.Name;
-                if (opacityValues.ContainsKey(key))
-                {
-                    opacity = opacityValues[key];
-                    write = true;
-                }
-                if (!attr.Attribute.InAttributeDictionary || _attributes.ContainsKey(key))
-                {
-                    opacity *= (float)attr.Property.GetValue(this);
-                    write = true;
-                }
-                if (write)
-                {
-                    opacity = (float)Math.Round(opacity, 2, MidpointRounding.AwayFromZero);
-                    var value = (string)attr.Property.Converter.ConvertTo(opacity, typeof(string));
-                    if (!string.IsNullOrEmpty(value) && !SvgDefaults.IsDefault(attr.Attribute.Name, attr.Property.ComponentType.Name, value))
-                        writer.WriteAttributeString(attr.Attribute.NamespaceAndName, value);
-                }
+                Inherited = true;
             }
 
             return styles;

--- a/Source/SvgElement.cs
+++ b/Source/SvgElement.cs
@@ -403,7 +403,7 @@ namespace Svg
         [SvgAttribute("id")]
         public string ID
         {
-            get { return this.Attributes.GetAttribute<string>("id"); }
+            get { return GetAttribute<string>("id", false); }
             set
             {
                 SetAndForceUniqueID(value, false);


### PR DESCRIPTION
ref. [this comment](https://github.com/vvvv/SVG/pull/471#pullrequestreview-242359019).

## sample SVG.

```svg
<?xml version="1.0" encoding="utf-8"?>
<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" width="100" height="80">
<text fill="blue"  font-size="12" font-family="Verdana"                      x="10" y="20"> SVG  is  XML. </text>
<text fill="red"   font-size="12" font-family="Verdana" xml:space="default"  x="10" y="40"> SVG  is  XML. </text>
<text fill="green" font-size="12" font-family="Verdana" xml:space="preserve" x="10" y="60"> SVG  is  XML. </text>
</svg>
```

## output.svg

```svg
<?xml version="1.0" encoding="utf-8"?>
<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
<svg x="0" y="0" width="100" height="80" preserveAspectRatio="xMidYMid" font-size="0" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xml="http://www.w3.org/XML/1998/namespace" version="1.1">
  <text x="10" y="20" font-family="Verdana" font-size="12" style="fill:blue;"> SVG  is  XML. </text>
  <text xml:space="default" x="10" y="40" font-family="Verdana" font-size="12" style="fill:red;"> SVG  is  XML. </text>
  <text xml:space="preserve" x="10" y="60" font-family="Verdana" font-size="12" style="fill:green;"> SVG  is  XML. </text>
</svg>
```