### PR TITLE
Gdi+ related errors are now wrapped in a specific exception with more detailed information

### DIFF
--- a/Source/Exceptions/SvgGdiPlusCannotBeLoadedException.cs
+++ b/Source/Exceptions/SvgGdiPlusCannotBeLoadedException.cs
@@ -1,0 +1,8 @@
+using System;
+namespace Svg
+{
+    public class SvgGdiPlusCannotBeLoadedException : Exception
+    {
+        public SvgGdiPlusCannotBeLoadedException(Exception inner) : base("Cannot initialize gdi+ libraries. This is likely to be caused by running on a non-Windows OS without proper gdi+ replacement. Please refer to the documentation for more details.", inner) {}
+    }
+}

--- a/Source/Svg.csproj
+++ b/Source/Svg.csproj
@@ -137,12 +137,17 @@
     </PackageReference>
   </ItemGroup>
 
+  <!-- Mac specific include -->
+  <!--ItemGroup>
+    <PackageReference Include="runtime.osx.10.10-x64.CoreCompat.System.Drawing" Version="5.6.20" />
+  </ItemGroup-->
+
   <ItemGroup>
     <Compile Remove=".\External\ExCSS\Parser.generated.cs" />
     <Compile Remove=".\External\ExCSS\ParserX.cs" />
     <Compile Remove=".\Resources\svg11.dtd" />
   </ItemGroup>
-
+  
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.167">
       <PrivateAssets>all</PrivateAssets>

--- a/Source/SvgDocument.cs
+++ b/Source/SvgDocument.cs
@@ -280,139 +280,177 @@ namespace Svg
 
         private static T Open<T>(XmlReader reader) where T : SvgDocument, new()
         {
-            var elementStack = new Stack<SvgElement>();
-            bool elementEmpty;
-            SvgElement element = null;
-            SvgElement parent;
-            T svgDocument = null;
-            var elementFactory = new SvgElementFactory();
-
-            var styles = new List<ISvgNode>();
-
-            while (reader.Read())
+            try
             {
-                try
+                var elementStack = new Stack<SvgElement>();
+                bool elementEmpty;
+                SvgElement element = null;
+                SvgElement parent;
+                T svgDocument = null;
+                var elementFactory = new SvgElementFactory();
+
+                var styles = new List<ISvgNode>();
+
+                while (reader.Read())
                 {
-                    switch (reader.NodeType)
+                    try
                     {
-                        case XmlNodeType.Element:
-                            // Does this element have a value or children
-                            // (Must do this check here before we progress to another node)
-                            elementEmpty = reader.IsEmptyElement;
-                            // Create element
-                            if (elementStack.Count > 0)
-                            {
-                                element = elementFactory.CreateElement(reader, svgDocument);
-                            }
-                            else
-                            {
-                                svgDocument = elementFactory.CreateDocument<T>(reader);
-                                element = svgDocument;
-                            }
-
-                            // Add to the parents children
-                            if (elementStack.Count > 0)
-                            {
-                                parent = elementStack.Peek();
-                                if (parent != null && element != null)
-                                {
-                                    parent.Children.Add(element);
-                                    parent.Nodes.Add(element);
-                                }
-                            }
-
-                            // Push element into stack
-                            elementStack.Push(element);
-
-                            // Need to process if the element is empty
-                            if (elementEmpty)
-                            {
-                                goto case XmlNodeType.EndElement;
-                            }
-
-                            break;
-                        case XmlNodeType.EndElement:
-
-                            // Pop the element out of the stack
-                            element = elementStack.Pop();
-
-                            if (element.Nodes.OfType<SvgContentNode>().Any())
-                            {
-                                element.Content = (from e in element.Nodes select e.Content).Aggregate((p, c) => p + c);
-                            }
-                            else
-                            {
-                                element.Nodes.Clear(); // No sense wasting the space where it isn't needed
-                            }
-
-                            var unknown = element as SvgUnknownElement;
-                            if (unknown != null && unknown.ElementName == "style")
-                            {
-                                styles.Add(unknown);
-                            }
-                            break;
-                        case XmlNodeType.CDATA:
-                        case XmlNodeType.Text:
-                            element = elementStack.Peek();
-                            element.Nodes.Add(new SvgContentNode() { Content = reader.Value });
-                            break;
-                        case XmlNodeType.EntityReference:
-                            reader.ResolveEntity();
-                            element = elementStack.Peek();
-                            element.Nodes.Add(new SvgContentNode() { Content = reader.Value });
-                            break;
-                    }
-                }
-                catch (Exception exc)
-                {
-                    Trace.TraceError(exc.Message);
-                }
-            }
-
-            if (styles.Any())
-            {
-                var cssTotal = styles.Select((s) => s.Content).Aggregate((p, c) => p + Environment.NewLine + c);
-                var cssParser = new Parser();
-                var sheet = cssParser.Parse(cssTotal);
-                AggregateSelectorList aggList;
-                IEnumerable<BaseSelector> selectors;
-                IEnumerable<SvgElement> elemsToStyle;
-
-                foreach (var rule in sheet.StyleRules)
-                {
-                    aggList = rule.Selector as AggregateSelectorList;
-                    if (aggList != null && aggList.Delimiter == ",")
-                    {
-                        selectors = aggList;
-                    }
-                    else
-                    {
-                        selectors = Enumerable.Repeat(rule.Selector, 1);
-                    }
-
-                    foreach (var selector in selectors)
-                    {
-                        try
+                        switch (reader.NodeType)
                         {
-                            elemsToStyle = svgDocument.QuerySelectorAll(rule.Selector.ToString(), elementFactory);
-                            foreach (var elem in elemsToStyle)
-                            {
-                                foreach (var decl in rule.Declarations)
+                            case XmlNodeType.Element:
+                                // Does this element have a value or children
+                                // (Must do this check here before we progress to another node)
+                                elementEmpty = reader.IsEmptyElement;
+                                // Create element
+                                if (elementStack.Count > 0)
                                 {
-                                    elem.AddStyle(decl.Name, decl.Term.ToString(), rule.Selector.GetSpecificity());
+                                    element = elementFactory.CreateElement(reader, svgDocument);
                                 }
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            Trace.TraceWarning(ex.Message);
+                                else
+                                {
+                                    svgDocument = elementFactory.CreateDocument<T>(reader);
+                                    element = svgDocument;
+                                }
+
+                                // Add to the parents children
+                                if (elementStack.Count > 0)
+                                {
+                                    parent = elementStack.Peek();
+                                    if (parent != null && element != null)
+                                    {
+                                        parent.Children.Add(element);
+                                        parent.Nodes.Add(element);
+                                    }
+                                }
+
+                                // Push element into stack
+                                elementStack.Push(element);
+
+                                // Need to process if the element is empty
+                                if (elementEmpty)
+                                {
+                                    goto case XmlNodeType.EndElement;
+                                }
+
+                                break;
+                            case XmlNodeType.EndElement:
+
+                                // Pop the element out of the stack
+                                element = elementStack.Pop();
+
+                                if (element.Nodes.OfType<SvgContentNode>().Any())
+                                {
+                                    element.Content = (from e in element.Nodes select e.Content).Aggregate((p, c) => p + c);
+                                }
+                                else
+                                {
+                                    element.Nodes.Clear(); // No sense wasting the space where it isn't needed
+                                }
+
+                                var unknown = element as SvgUnknownElement;
+                                if (unknown != null && unknown.ElementName == "style")
+                                {
+                                    styles.Add(unknown);
+                                }
+                                break;
+                            case XmlNodeType.CDATA:
+                            case XmlNodeType.Text:
+                                element = elementStack.Peek();
+                                element.Nodes.Add(new SvgContentNode() { Content = reader.Value });
+                                break;
+                            case XmlNodeType.EntityReference:
+                                reader.ResolveEntity();
+                                element = elementStack.Peek();
+                                element.Nodes.Add(new SvgContentNode() { Content = reader.Value });
+                                break;
                         }
                     }
+                    catch (Exception exc)
+                    {
+                        Trace.TraceError(exc.Message);
+                        if(ExceptionCaughtIsGdiPlusRelated(exc)) { throw; } //Gdi+ errors should be rethrown
+                    }
                 }
-            }
 
-            if (svgDocument != null) FlushStyles(svgDocument);
-            return svgDocument;
+                if (styles.Any())
+                {
+                    var cssTotal = styles.Select((s) => s.Content).Aggregate((p, c) => p + Environment.NewLine + c);
+                    var cssParser = new Parser();
+                    var sheet = cssParser.Parse(cssTotal);
+                    AggregateSelectorList aggList;
+                    IEnumerable<BaseSelector> selectors;
+                    IEnumerable<SvgElement> elemsToStyle;
+
+                    foreach (var rule in sheet.StyleRules)
+                    {
+                        aggList = rule.Selector as AggregateSelectorList;
+                        if (aggList != null && aggList.Delimiter == ",")
+                        {
+                            selectors = aggList;
+                        }
+                        else
+                        {
+                            selectors = Enumerable.Repeat(rule.Selector, 1);
+                        }
+
+                        foreach (var selector in selectors)
+                        {
+                            try
+                            {
+                                elemsToStyle = svgDocument.QuerySelectorAll(rule.Selector.ToString(), elementFactory);
+                                foreach (var elem in elemsToStyle)
+                                {
+                                    foreach (var decl in rule.Declarations)
+                                    {
+                                        elem.AddStyle(decl.Name, decl.Term.ToString(), rule.Selector.GetSpecificity());
+                                    }
+                                }
+                            }
+                            catch (Exception ex)
+                            {
+                                Trace.TraceWarning(ex.Message);
+                                if(ExceptionCaughtIsGdiPlusRelated(ex)) { throw; } //Gdi+ errors should be rethrown
+                            }
+                        }
+                    }
+                }
+
+                if (svgDocument != null) FlushStyles(svgDocument);
+                return svgDocument;
+            }
+            //GDI+ loading errors will result in TypeInitializationExceptions, for readability we will catch and wrap the error
+            catch(Exception e)
+            {
+                if(ExceptionCaughtIsGdiPlusRelated(e))
+                {
+                    //Throw only the customized excpetion if we are sure the gdi+ is causing the problem
+                    throw new SvgGdiPlusCannotBeLoadedException(e);
+                }
+                //No wrapping, just retrow the exception
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Check if the current exception or one of its children is the targeted GDI+ exception. 
+        /// It can be hidden in one of the InnerExceptions, so we need to iterate over them.
+        /// </summary>
+        /// <param name="e">The exception to validate against the GDI+ check</param>
+        private static bool ExceptionCaughtIsGdiPlusRelated(Exception e)
+        {
+            var currE = e;
+            int cnt = 0; //Keep track of depth to prevent endless-loops
+            while(currE != null && cnt < 10)
+            {
+                var typeException = currE as DllNotFoundException;
+                if(typeException?.Message?.LastIndexOf("libgdiplus", StringComparison.OrdinalIgnoreCase) > -1) 
+                {
+                    return true;
+                }
+                currE = currE.InnerException;
+                cnt++;
+            }
+            return false;
         }
 
         private static void FlushStyles(SvgElement elem)

--- a/Tests/Svg.UnitTests/LexerIssueTests.cs
+++ b/Tests/Svg.UnitTests/LexerIssueTests.cs
@@ -103,6 +103,7 @@ namespace Svg.UnitTests
             str = str.Replace(LexerTemplateReplaceToken, testContent);
             var xml = GetXMLDocFromString(str);
             var doc = OpenSvg(xml);
+            if(doc == null) { Assert.Fail("Expected a document result, but got null"); }
             return doc;
         }
 

--- a/Tests/Svg.UnitTests/Svg.UnitTests.csproj
+++ b/Tests/Svg.UnitTests/Svg.UnitTests.csproj
@@ -63,21 +63,19 @@
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
   </ItemGroup>
-
+  <ItemGroup Condition="'$(RuntimeIdentifier)'=='osx.10.14-x64'">
+    <PackageReference Include="runtime.osx.10.10-x64.CoreCompat.System.Drawing" Version="5.6.20" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Source\SVG.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.2'">
-
     <Reference Include="WindowsBase" />
-
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net452'">
-
     <Reference Include="WindowsBase" />
-
   </ItemGroup>
 
 </Project>

--- a/Tests/Svg.UnitTests/Svg.UnitTests.csproj
+++ b/Tests/Svg.UnitTests/Svg.UnitTests.csproj
@@ -63,9 +63,7 @@
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
   </ItemGroup>
-  <ItemGroup Condition="'$(RuntimeIdentifier)'=='osx.10.14-x64'">
-    <PackageReference Include="runtime.osx.10.10-x64.CoreCompat.System.Drawing" Version="5.6.20" />
-  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\Source\SVG.csproj" />
   </ItemGroup>


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #501

#### What does this implement/fix? Explain your changes.
SvgDocument.Open now has some additional checks to see if the error might be related to the gdi+ issues described in #501. We scan the exception for the presence of a certain type of exception and message in the exception. The specific exceptions is re-thrown (while other exceptions are only logged and not thrown) and is handled at the end of the Load function. If we are handling the specific gdi+ exception, we will wrap it in an exception with a bit more detail.

#### Any other comments?
Added a commented ItemGroup for the CoreCompat package in the Svg.csproj file. This is commented by default, to enable building/running on Mac uncomment the ItemGroup.

<!--
Thanks for contributing!
-->
