### PR TITLE
Fix: #507 "SvgText fill missing when custom attribute style set"

### DIFF
--- a/Source/SvgElement.cs
+++ b/Source/SvgElement.cs
@@ -596,8 +596,14 @@ namespace Svg
             }
 
             //add the custom attributes
+            var additionalStyleValue = string.Empty;
             foreach (var item in this._customAttributes)
             {
+                if (item.Key.Equals("style") && styles.Any())
+                {
+                    additionalStyleValue = item.Value;
+                    continue;
+                }
                 writer.WriteAttributeString(item.Key, item.Value);
             }
 
@@ -605,7 +611,7 @@ namespace Svg
             if (styles.Any())
             {
                 writer.WriteAttributeString("style", (from s in styles
-                                                      select s.Key + ":" + s.Value + ";").Aggregate((p, c) => p + c));
+                                                      select s.Key + ":" + s.Value + ";").Aggregate((p, c) => p + c) + additionalStyleValue);
             }
         }
 

--- a/Tests/Svg.UnitTests/StyleTest.cs
+++ b/Tests/Svg.UnitTests/StyleTest.cs
@@ -1,0 +1,45 @@
+﻿using System.Drawing;
+using System.IO;
+using System.Xml;
+using NUnit.Framework;
+
+namespace Svg.UnitTests
+{
+    [TestFixture]
+    public class StyleTest
+    {
+        [Test]
+        public void TestStyleValue()
+        {
+            var document = new SvgDocument();
+            var text = new SvgText("Test")
+            {
+                X = { 0f },
+                Y = { 20f },
+                Fill = new SvgColourServer(Color.Blue),
+                CustomAttributes = { { "style", "test0:test0" } }
+            };
+            text.AddStyle("test1", "test1", 0);
+            document.Children.Add(text);
+            using (var stream = new MemoryStream())
+            {
+                document.Write(stream);
+                stream.Position = 0;
+
+                var xmlDoc = new XmlDocument
+                {
+                    XmlResolver = new SvgDtdResolver()
+                };
+                xmlDoc.Load(stream);
+
+                var attribute = xmlDoc.DocumentElement.FirstChild.Attributes["style"];
+                Assert.IsNotNull(attribute);
+
+                var styles = attribute.InnerText.Split(';');
+                Assert.Contains("test0:test0", styles);
+                Assert.Contains("test1:test1", styles);
+                Assert.Contains("fill:blue", styles);
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

Fixes #507

#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->

#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
