### PR TITLE
Apply Styles

### DIFF
--- a/Source/SvgDocument.cs
+++ b/Source/SvgDocument.cs
@@ -483,17 +483,8 @@ namespace Svg
                 }
             }
 
-            if (svgDocument != null) FlushStyles(svgDocument);
+            svgDocument?.FlushStyles(true);
             return svgDocument;
-        }
-
-        private static void FlushStyles(SvgElement elem)
-        {
-            elem.FlushStyles();
-            foreach (var child in elem.Children)
-            {
-                FlushStyles(child);
-            }
         }
 
         /// <summary>

--- a/Source/SvgElement.cs
+++ b/Source/SvgElement.cs
@@ -50,7 +50,6 @@ namespace Svg
 
         private Dictionary<string, SortedDictionary<int, string>> _styles = new Dictionary<string, SortedDictionary<int, string>>();
 
-
         public void AddStyle(string name, string value, int specificity)
         {
             SortedDictionary<int, string> rules;
@@ -59,25 +58,29 @@ namespace Svg
                 rules = new SortedDictionary<int, string>();
                 _styles[name] = rules;
             }
-            while (rules.ContainsKey(specificity)) specificity++;
+            while (rules.ContainsKey(specificity)) ++specificity;
             rules[specificity] = value;
         }
-        public void FlushStyles()
+
+        public void FlushStyles(bool children = false)
+        {
+            FlushStyles();
+            if (children)
+                foreach (var child in Children)
+                    child.FlushStyles(children);
+        }
+
+        private void FlushStyles()
         {
             if (_styles.Any())
             {
                 var styles = new Dictionary<string, SortedDictionary<int, string>>();
                 foreach (var s in _styles)
-                {
-                    if (!SvgElementFactory.SetPropertyValue(this, s.Key, s.Value.Last().Value, this.OwnerDocument, isStyle: true))
-                    {
+                    if (!SvgElementFactory.SetPropertyValue(this, s.Key, s.Value.Last().Value, OwnerDocument, true))
                         styles.Add(s.Key, s.Value);
-                    }
-                }
                 _styles = styles;
             }
         }
-
 
         public bool ContainsAttribute(string name)
         {

--- a/Source/SvgElement.cs
+++ b/Source/SvgElement.cs
@@ -50,6 +50,12 @@ namespace Svg
 
         private Dictionary<string, SortedDictionary<int, string>> _styles = new Dictionary<string, SortedDictionary<int, string>>();
 
+        /// <summary>
+        /// Add style.
+        /// </summary>
+        /// <param name="name">The style name.</param>
+        /// <param name="value">The style value.</param>
+        /// <param name="specificity">The specificity value.</param>
         public void AddStyle(string name, string value, int specificity)
         {
             SortedDictionary<int, string> rules;
@@ -62,6 +68,10 @@ namespace Svg
             rules[specificity] = value;
         }
 
+        /// <summary>
+        /// Flush styles.
+        /// </summary>
+        /// <param name="children">If true, flush styles to the children.</param>
         public void FlushStyles(bool children = false)
         {
             FlushStyles();

--- a/Tests/Svg.UnitTests/StyleTest.cs
+++ b/Tests/Svg.UnitTests/StyleTest.cs
@@ -21,6 +21,7 @@ namespace Svg.UnitTests
             };
             text.AddStyle("test1", "test1", 0);
             document.Children.Add(text);
+            document.FlushStyles(true);
             using (var stream = new MemoryStream())
             {
                 document.Write(stream);
@@ -40,6 +41,25 @@ namespace Svg.UnitTests
                 Assert.Contains("test1:test1", styles);
                 Assert.Contains("fill:blue", styles);
             }
+        }
+
+        [Test]
+        public void TestApplyStyle()
+        {
+            var document = new SvgDocument();
+            var rectangle = new SvgRectangle()
+            {
+                X = 0f,
+                Y = 0f,
+                Width = 10f,
+                Height = 10f,
+            };
+            rectangle.AddStyle("fill", "blue", 0);
+            document.Children.Add(rectangle);
+            document.FlushStyles(true);
+
+            Assert.IsInstanceOf(typeof(SvgColourServer), rectangle.Fill);
+            Assert.AreEqual(((SvgColourServer)rectangle.Fill).Colour, Color.Blue);
         }
     }
 }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

Relation #507

#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->

Provides a way to apply styles by programming generation as follows:
```cs
var doc = new SvgDocument
{
    Width = 100f,
    Height = 100f,
};
var rect = new SvgRectangle()
{
    X = 10f,
    Y = 10f,
    Width = 80f,
    Height = 80f,
};
rect.AddStyle("fill", "blue", 0);
doc.Children.Add(rect);
doc.FlushStyles(true);  // Apply Styles
```

##### output

![output](https://user-images.githubusercontent.com/11144112/61159531-4a4f3500-a537-11e9-86ef-be40432a5490.png)


#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
