### PR TITLE
Fixed saving of attributes with default value

### DIFF
--- a/Source/DataTypes/SvgUnitCollection.cs
+++ b/Source/DataTypes/SvgUnitCollection.cs
@@ -13,6 +13,8 @@ namespace Svg
     [TypeConverter(typeof(SvgUnitCollectionConverter))]
     public class SvgUnitCollection : ObservableCollection<SvgUnit>
     {
+        internal bool IsNull { get; set; }
+
         public void AddRange(IEnumerable<SvgUnit> collection)
         {
             if (collection == null)
@@ -81,7 +83,8 @@ namespace Svg
                     return null;
 
                 var units = new SvgUnitCollection();
-                if (!s.Equals("none", StringComparison.OrdinalIgnoreCase))
+                units.IsNull = s.Equals("none", StringComparison.OrdinalIgnoreCase);
+                if (!units.IsNull)
                     foreach (var point in s.Split(new char[] { ',', ' ', '\r', '\n', '\t' }, StringSplitOptions.RemoveEmptyEntries))
                     {
                         var newUnit = (SvgUnit)_unitConverter.ConvertFrom(point.Trim());
@@ -106,7 +109,11 @@ namespace Svg
         public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
         {
             if (value != null && destinationType == typeof(string))
+            {
+                if (((SvgUnitCollection)value).IsNull)
+                    return "none";
                 return ((SvgUnitCollection)value).ToString();
+            }
 
             return base.ConvertTo(context, culture, value, destinationType);
         }

--- a/Source/SvgElement.cs
+++ b/Source/SvgElement.cs
@@ -643,18 +643,22 @@ namespace Svg
                             var forceWrite = false;
                             var writeStyle = attr.Attribute.Name == "fill" || attr.Attribute.Name == "stroke";
 
-                            if (writeStyle && (Parent != null))
+                            if (Parent != null)
                             {
-                                if (propertyValue == SvgColourServer.NotSet) continue;
+                                if (writeStyle && propertyValue == SvgColourServer.NotSet)
+                                    continue;
 
                                 object parentValue;
                                 if (TryResolveParentAttributeValue(attr.Attribute.Name, out parentValue))
                                 {
                                     if ((parentValue == propertyValue)
                                         || ((parentValue != null) && parentValue.Equals(propertyValue)))
-                                        continue;
-
-                                    forceWrite = true;
+                                    {
+                                        if (writeStyle)
+                                            continue;
+                                    }
+                                    else
+                                        forceWrite = true;
                                 }
                             }
 


### PR DESCRIPTION
- these had not been written even if they overwrote an inherited attribute
- allow SvgUnitCollection to be none (needed to save stroke-dasharray="none")

I noticed while checking other images in the test runner that the image from PR #504 was not correctly saved, due to the stroke-dasharray (which was none, but overwrote the inherited setting) not being written.