### PR TITLE
Fix ToSvgString

### DIFF
--- a/Source/Paths/SvgPathBuilder.cs
+++ b/Source/Paths/SvgPathBuilder.cs
@@ -14,7 +14,7 @@ namespace Svg
     {
         public static string ToSvgString(this PointF p)
         {
-            return p.X.ToString() + " " + p.Y.ToString();
+            return p.X.ToString(CultureInfo.InvariantCulture) + " " + p.Y.ToString(CultureInfo.InvariantCulture);
         }
     }
 

--- a/Source/SvgNodeReader.cs
+++ b/Source/SvgNodeReader.cs
@@ -1,10 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Xml;
-using System.IO;
-using System.Collections.Specialized;
 
 namespace Svg
 {
@@ -18,7 +14,7 @@ namespace Svg
         public SvgNodeReader(XmlNode node, Dictionary<string, string> entities)
             : base(node)
         {
-            this._entities = entities;
+            _entities = entities ?? new Dictionary<string, string>();
         }
 
         /// <summary>
@@ -30,7 +26,7 @@ namespace Svg
         {
             get
             {
-                return (this._customValue) ? this._value : base.Value;
+                return _customValue ? _value : base.Value;
             }
         }
 
@@ -43,20 +39,7 @@ namespace Svg
         {
             get
             {
-                return (this._customValue) ? this._localName : base.LocalName;
-            }
-        }
-
-        private IDictionary<string, string> Entities
-        {
-            get
-            {
-                if (this._entities == null)
-                {
-                    this._entities = new Dictionary<string, string>();
-                }
-
-                return this._entities;
+                return _customValue ? _localName : base.LocalName;
             }
         }
 
@@ -72,20 +55,20 @@ namespace Svg
 
             if (moved)
             {
-                this._localName = base.LocalName;
+                _localName = base.LocalName;
 
-                if (this.ReadAttributeValue())
+                if (ReadAttributeValue())
                 {
-                    if (this.NodeType == XmlNodeType.EntityReference)
+                    if (NodeType == XmlNodeType.EntityReference)
                     {
-                        this.ResolveEntity();
+                        ResolveEntity();
                     }
                     else
                     {
-                        this._value = base.Value;
+                        _value = base.Value;
                     }
                 }
-                this._customValue = true;
+                _customValue = true;
             }
 
             return moved;
@@ -100,12 +83,12 @@ namespace Svg
         /// <exception cref="T:System.Xml.XmlException">An error occurred while parsing the XML. </exception>
         public override bool Read()
         {
-            this._customValue = false;
+            _customValue = false;
             bool read = base.Read();
 
-            if (this.NodeType == XmlNodeType.DocumentType)
+            if (NodeType == XmlNodeType.DocumentType)
             {
-                this.ParseEntities();
+                ParseEntities();
             }
 
             return read;
@@ -114,7 +97,7 @@ namespace Svg
         private void ParseEntities()
         {
             const string entityText = "<!ENTITY";
-            string[] entities = this.Value.Split(new string[] { entityText }, StringSplitOptions.None);
+            string[] entities = Value.Split(new string[] { entityText }, StringSplitOptions.None);
             string[] parts = null;
             string name = null;
             string value = null;
@@ -128,9 +111,9 @@ namespace Svg
 
                 parts = entity.Trim().Split(new char[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
                 name = parts[0];
-                value = parts[1].Split(new char[] { this.QuoteChar }, StringSplitOptions.RemoveEmptyEntries)[0];
+                value = parts[1].Split(new char[] { QuoteChar }, StringSplitOptions.RemoveEmptyEntries)[0];
 
-                this.Entities.Add(name, value);
+                _entities.Add(name, value);
             }
         }
 
@@ -139,18 +122,18 @@ namespace Svg
         /// </summary>
         public override void ResolveEntity()
         {
-            if (this.NodeType == XmlNodeType.EntityReference)
+            if (NodeType == XmlNodeType.EntityReference)
             {
-                if (this._entities.ContainsKey(this.Name))
+                if (_entities.ContainsKey(Name))
                 {
-                    this._value = this._entities[this.Name];
+                    _value = _entities[Name];
                 }
                 else
                 {
-                    this._value = string.Empty;
+                    _value = string.Empty;
                 }
 
-                this._customValue = true;
+                _customValue = true;
             }
         }
     }

--- a/Tests/Svg.UnitTests/NodeReaderTests.cs
+++ b/Tests/Svg.UnitTests/NodeReaderTests.cs
@@ -1,0 +1,19 @@
+﻿using NUnit.Framework;
+
+namespace Svg.UnitTests
+{
+    [TestFixture]
+    public class SvgNodeReaderTests : SvgTestHelper
+    {
+        protected override string TestResource { get { return GetFullResourceString("Issue518_Entities.Entities.svg"); } }
+        //protected override int ExpectedSize { get { return 4300; } } // original image has 4314 bytes
+
+        [Test]
+        public void ReadingEntitiesFromXmlSucceeds()
+        {
+            var xmlDoc = GetXMLDocFromResource();
+            var doc = SvgDocument.Open(xmlDoc);
+            Assert.DoesNotThrow(() => doc.Draw());
+        }
+    }
+}

--- a/Tests/Svg.UnitTests/Resources/Issue518_Entities/Entities.svg
+++ b/Tests/Svg.UnitTests/Resources/Issue518_Entities/Entities.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.4, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN" "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd" [
+	<!ENTITY ns_extend "http://ns.adobe.com/Extensibility/1.0/">
+	<!ENTITY ns_ai "http://ns.adobe.com/AdobeIllustrator/10.0/">
+	<!ENTITY ns_graphs "http://ns.adobe.com/Graphs/1.0/">
+	<!ENTITY ns_vars "http://ns.adobe.com/Variables/1.0/">
+	<!ENTITY ns_imrep "http://ns.adobe.com/ImageReplacement/1.0/">
+	<!ENTITY ns_sfw "http://ns.adobe.com/SaveForWeb/1.0/">
+	<!ENTITY ns_custom "http://ns.adobe.com/GenericCustomNamespace/1.0/">
+	<!ENTITY ns_adobe_xpath "http://ns.adobe.com/XPath/1.0/">
+]>
+<svg version="1.0" id="Image_1_" xmlns:x="&ns_extend;" xmlns:i="&ns_ai;" xmlns:graph="&ns_graphs;"
+	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="100" height="100"
+	 style="enable-background:new 0 0 3000 250;" xml:space="preserve">
+     <path fill="#FF0000" stroke="#000000" stroke-linejoin="round" stroke-linecap="round" stroke-width="10" d="M 10,10 L 90,10 L 90,90 Z" />
+</svg>

--- a/Tests/Svg.UnitTests/Svg.UnitTests.csproj
+++ b/Tests/Svg.UnitTests/Svg.UnitTests.csproj
@@ -62,6 +62,9 @@
     <EmbeddedResource Include="Resources\Issue399_LexerIssue\EmptyDTag.svg" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="Resources\Issue518_Entities\Entities.svg" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->

<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->
The `ToSvgString` method used current culture which produces invalid path data on some culture (uses `,` instead of `.` for separator.
