### PR TITLE
Fix: y2 default value.

### DIFF
--- a/Source/SvgDefinitionDefaults.cs
+++ b/Source/SvgDefinitionDefaults.cs
@@ -14,7 +14,7 @@ namespace Svg
                 { "SvgRadialGradientServer", new Dictionary<string, string>
                 { { "cx", "50%" }, { "cy", "50%" }, { "r", "50%" } } },
                 { "SvgLinearGradientServer", new Dictionary<string, string>
-                { { "x1", "0%" }, { "x2", "100%" }, { "y1", "0%" }, { "y2", "100%" } } },
+                { { "x1", "0%" }, { "x2", "100%" }, { "y1", "0%" }, { "y2", "0%" } } },
 
                 { "SvgFragment", new Dictionary<string, string>
                 { { "space", "default" } } },


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->

In \<linearGradient\> element, `y2` attribute default value is '0%'.

https://www.w3.org/TR/SVG11/pservers.html#LinearGradientElementY2Attribute

#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
