### PR TITLE
Updated core compat package for Mac

### DIFF
--- a/Source/Svg.csproj
+++ b/Source/Svg.csproj
@@ -125,10 +125,12 @@
   </ItemGroup>
 
   <!-- Mac specific include -->
-  <!-- <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.2'">
-    <PackageReference Include="runtime.osx.10.10-x64.CoreCompat.System.Drawing" Version="5.6.20" />
-  </ItemGroup> -->
-
+  <!--
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.2'">
+    <PackageReference Include="runtime.osx.10.10-x64.CoreCompat.System.Drawing" Version="5.8.64" />
+  </ItemGroup>
+  -->
+  
   <ItemGroup>
     <Compile Remove=".\External\ExCSS\Parser.generated.cs" />
     <Compile Remove=".\External\ExCSS\ParserX.cs" />


### PR DESCRIPTION
#### Reference Issue
Fixes #548 issue on MacOs

#### What does this implement/fix? Explain your changes.
Updated the CoreCompat package to a more recent version. This fixes issues with the fonts as described in #548 