### PR TITLE
Added support for the SvgScript tag

### DIFF
--- a/Source/Document Structure/SvgScript.cs
+++ b/Source/Document Structure/SvgScript.cs
@@ -9,9 +9,36 @@ namespace Svg
     [SvgElement("script")]
     public class SvgScript : SvgElement
     {
+
+        private string _scriptType;
+
+        [SvgAttribute("type")]
+        public string ScriptType  //TODO: Enum?
+        { 
+            get { return _scriptType; } 
+            set { _scriptType = value; } 
+        }
+
+        private string _crossOrigin;
+
+        [SvgAttribute("crossorigin")]
+        public string CrossOrigin 
+        {
+            get { return _crossOrigin; }
+            set { _crossOrigin = value; }
+        }
+
+        private string _href;
+        [SvgAttribute("href")]
+        public string Href //TODO: URI? 
+        {
+            get { return _href; }
+            set { _href = value; }
+        }
+
         public override SvgElement DeepCopy()
         {
-            throw new System.NotImplementedException();
+            return DeepCopy<SvgScript>();        
         }
     }
 }

--- a/Source/Document Structure/SvgScript.cs
+++ b/Source/Document Structure/SvgScript.cs
@@ -1,0 +1,17 @@
+using System.Drawing;
+using System.Drawing.Drawing2D;
+
+namespace Svg
+{
+    /// <summary>
+    /// An element used to define scripts within SVG documents.
+    /// </summary>
+    [SvgElement("script")]
+    public class SvgScript : SvgElement
+    {
+        public override SvgElement DeepCopy()
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/Source/Document Structure/SvgScript.cs
+++ b/Source/Document Structure/SvgScript.cs
@@ -20,7 +20,7 @@ namespace Svg
         private string _scriptType;
 
         [SvgAttribute("type")]
-        public string ScriptType  //TODO: Enum?
+        public string ScriptType 
         { 
             get { return _scriptType; } 
             set { _scriptType = value; } 
@@ -37,15 +37,45 @@ namespace Svg
 
         private string _href;
         [SvgAttribute("href")]
-        public string Href //TODO: URI? 
+        public string Href
         {
             get { return _href; }
             set { _href = value; }
         }
-
+    
         public override SvgElement DeepCopy()
         {
             return DeepCopy<SvgScript>();        
+        }
+
+        public override bool ShouldWriteElement() 
+        { 
+            return true;    
+        }
+
+        protected override void WriteAttributes(System.Xml.XmlTextWriter writer)
+        {
+            if(!string.IsNullOrWhiteSpace(Href))
+            {
+                writer.WriteAttributeString("href", Href);
+            }
+            if(!string.IsNullOrWhiteSpace(CrossOrigin))
+            {
+                writer.WriteAttributeString("crossorigin", CrossOrigin);
+            }
+            if(!string.IsNullOrWhiteSpace(ScriptType))
+            {
+                writer.WriteAttributeString("type", ScriptType);
+            }
+        }
+
+        protected override void WriteChildren(System.Xml.XmlTextWriter writer)
+        {
+            if(!string.IsNullOrWhiteSpace(Content))
+            {
+                //Always put the script in a CDATA tag
+                writer.WriteCData(this.Content);
+            }
         }
     }
 }

--- a/Source/Document Structure/SvgScript.cs
+++ b/Source/Document Structure/SvgScript.cs
@@ -18,51 +18,32 @@ namespace Svg
             set { this.Content = value; }
         }
 
-        private string _scriptType;
 
         [SvgAttribute("type")]
         public string ScriptType 
         { 
-            get { return _scriptType; } 
-            set { _scriptType = value; } 
+            get { return GetAttribute<string>("type", false); } 
+            set { Attributes["type"] = value; } 
         }
 
-        private string _crossOrigin;
 
         [SvgAttribute("crossorigin")]
         public string CrossOrigin 
         {
-            get { return _crossOrigin; }
-            set { _crossOrigin = value; }
+            get { return GetAttribute<string>("crossorigin",false); }
+            set { Attributes["crossorigin"] = value; }
         }
 
-        private string _href;
         [SvgAttribute("href")]
         public string Href
         {
-            get { return _href; }
-            set { _href = value; }
+            get { return GetAttribute<string>("href", false); }
+            set { Attributes["href"] = value; }
         }
     
         public override SvgElement DeepCopy()
         {
             return DeepCopy<SvgScript>();        
-        }
-
-        protected override void WriteAttributes(XmlTextWriter writer)
-        {
-            if(!string.IsNullOrEmpty(Href))
-            {
-                writer.WriteAttributeString("href", Href);
-            }
-            if(!string.IsNullOrEmpty(CrossOrigin))
-            {
-                writer.WriteAttributeString("crossorigin", CrossOrigin);
-            }
-            if(!string.IsNullOrEmpty(ScriptType))
-            {
-                writer.WriteAttributeString("type", ScriptType);
-            }
         }
 
         protected override void WriteChildren(System.Xml.XmlTextWriter writer)

--- a/Source/Document Structure/SvgScript.cs
+++ b/Source/Document Structure/SvgScript.cs
@@ -1,5 +1,6 @@
 using System.Drawing;
 using System.Drawing.Drawing2D;
+using System.Xml;
 
 namespace Svg
 {
@@ -48,12 +49,7 @@ namespace Svg
             return DeepCopy<SvgScript>();        
         }
 
-        public override bool ShouldWriteElement() 
-        { 
-            return true;    
-        }
-
-        protected override void WriteAttributes(System.Xml.XmlTextWriter writer)
+        protected override void WriteAttributes(XmlTextWriter writer)
         {
             if(!string.IsNullOrEmpty(Href))
             {

--- a/Source/Document Structure/SvgScript.cs
+++ b/Source/Document Structure/SvgScript.cs
@@ -55,15 +55,15 @@ namespace Svg
 
         protected override void WriteAttributes(System.Xml.XmlTextWriter writer)
         {
-            if(!string.IsNullOrWhiteSpace(Href))
+            if(!string.IsNullOrEmpty(Href))
             {
                 writer.WriteAttributeString("href", Href);
             }
-            if(!string.IsNullOrWhiteSpace(CrossOrigin))
+            if(!string.IsNullOrEmpty(CrossOrigin))
             {
                 writer.WriteAttributeString("crossorigin", CrossOrigin);
             }
-            if(!string.IsNullOrWhiteSpace(ScriptType))
+            if(!string.IsNullOrEmpty(ScriptType))
             {
                 writer.WriteAttributeString("type", ScriptType);
             }
@@ -71,7 +71,7 @@ namespace Svg
 
         protected override void WriteChildren(System.Xml.XmlTextWriter writer)
         {
-            if(!string.IsNullOrWhiteSpace(Content))
+            if(!string.IsNullOrEmpty(Content))
             {
                 //Always put the script in a CDATA tag
                 writer.WriteCData(this.Content);

--- a/Source/Document Structure/SvgScript.cs
+++ b/Source/Document Structure/SvgScript.cs
@@ -5,10 +5,17 @@ namespace Svg
 {
     /// <summary>
     /// An element used to define scripts within SVG documents.
+    /// Use the Script property to get the script content (proxies the content)
     /// </summary>
     [SvgElement("script")]
     public class SvgScript : SvgElement
     {
+
+        public string Script 
+        {
+            get { return this.Content; }
+            set { this.Content = value; }
+        }
 
         private string _scriptType;
 

--- a/Source/Document Structure/SvgScript.cs
+++ b/Source/Document Structure/SvgScript.cs
@@ -46,7 +46,7 @@ namespace Svg
             return DeepCopy<SvgScript>();        
         }
 
-        protected override void WriteChildren(System.Xml.XmlTextWriter writer)
+        protected override void WriteChildren(XmlTextWriter writer)
         {
             if(!string.IsNullOrEmpty(Content))
             {

--- a/Source/Svg.csproj
+++ b/Source/Svg.csproj
@@ -125,11 +125,11 @@
   </ItemGroup>
 
   <!-- Mac specific include -->
-  <!--
+  
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.2'">
     <PackageReference Include="runtime.osx.10.10-x64.CoreCompat.System.Drawing" Version="5.8.64" />
   </ItemGroup>
-  -->
+ 
   
   <ItemGroup>
     <Compile Remove=".\External\ExCSS\Parser.generated.cs" />

--- a/Tests/Svg.UnitTests/Resources/ScriptTag/TestFile.svg
+++ b/Tests/Svg.UnitTests/Resources/ScriptTag/TestFile.svg
@@ -1,0 +1,22 @@
+<svg width="100%" height="100%" viewBox="0 0 100 100"
+     xmlns="http://www.w3.org/2000/svg">
+  <script type="text/javascript">
+    // <![CDATA[
+    function change(evt) {
+      var target = evt.target;
+      var radius = target.getAttribute("r");
+
+      if (radius == 15) {
+        radius = 45;
+      } else {
+        radius = 15;
+      }
+
+      target.setAttribute("r",radius);
+   }
+   // ]]>
+  </script>
+
+  <circle cx="50" cy="50" r="45" fill="green"
+          onclick="change(evt)" />
+</svg>

--- a/Tests/Svg.UnitTests/Svg.UnitTests.csproj
+++ b/Tests/Svg.UnitTests/Svg.UnitTests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsTestProject>true</IsTestProject>
-    <TargetFrameworks>netcoreapp2.2;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.2;</TargetFrameworks>
+    <!-- <TargetFrameworks>netcoreapp2.2;net452</TargetFrameworks> -->
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>svgkey.snk</AssemblyOriginatorKeyFile>

--- a/Tests/Svg.UnitTests/Svg.UnitTests.csproj
+++ b/Tests/Svg.UnitTests/Svg.UnitTests.csproj
@@ -68,6 +68,9 @@
     <EmbeddedResource Include="Resources\Issue518_Entities\Entities.svg" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="Resources\ScriptTag\TestFile.svg" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />

--- a/Tests/Svg.UnitTests/SvgJavascriptTests.cs
+++ b/Tests/Svg.UnitTests/SvgJavascriptTests.cs
@@ -15,37 +15,74 @@ namespace Svg.UnitTests
     {
         protected override string TestResource { get { return GetFullResourceString("ScriptTag.TestFile.svg"); } } 
 
-        [Test]
-        public void SvgDocument_ReadFileWithScript_YieldsNoError()
+        /// <summary>
+        /// Helper to retrieve the script element from the test document (expected in the root as type SvgScript with the elementname script)
+        /// Will assert the element not being null and of the correct type
+        /// </summary>
+        private SvgScript GetScriptElementFromDocument(SvgDocument doc)
         {
-            //Expect to read a document with JS without problem
+            var el = doc.Children.FirstOrDefault(c => c.ElementName == "script");
+            Assert.IsNotNull(el, "Could not find the script element");
+            Assert.IsAssignableFrom(typeof(SvgScript), el, "Script tag was not correctly typed, expected SvgScript as type");
+            return el as SvgScript;
+        }
+
+        /// <summary>
+        /// Check if a file with a script tag can correctly be read (and the types are as expected)
+        /// </summary>
+        [Test]
+        public void SvgDocumentWithSvgScript_ReadFile_ScriptTagReadFromSvgInCorrectType()
+        {
             var doc = SvgDocument.Open(GetXMLDocFromResource(TestResource));
             Assert.IsNotNull(doc);
+            
             var circleElement = doc.Children.FirstOrDefault(c => c.ElementName == "circle");
             Assert.IsNotNull(circleElement, "Expected to find the circle element in the document");
             Assert.IsAssignableFrom(typeof(SvgCircle), circleElement, "Expected the found circle element to be of type SvgCircle");
             
-            var scriptElement = doc.Children.FirstOrDefault(c => c.ElementName == "script");
+            //Check if the type is correctly parsed
+            var scriptElement = GetScriptElementFromDocument(doc);
             Assert.IsNotNull(scriptElement, "Expected to find the script element in the document");
-            Assert.IsAssignableFrom(typeof(SvgScript), scriptElement, "Expected the found script element to be of type SvgScript");            
         }
 
+        /// <summary>
+        /// Test whether the attributes are parsed correctly (for now we only test the scripttype)
+        /// </summary>
         [Test]
-        public void SvgDocument_FileWithScript_CanRetrieveScriptTag()
+        public void SvgDocumentWithSvgScript_AttributeParsing_CorrectTypeAttribute()
         {
-            //Expected to retrieve the script tag(s) from the document
+            var doc = SvgDocument.Open(GetXMLDocFromResource(TestResource));
+            Assert.IsNotNull(doc);
+            
+            var tag = GetScriptElementFromDocument(doc);
+            Assert.AreEqual("text/javascript", tag.ScriptType, "Expected the type attribute to be read");
+        }
+
+        /// <summary>
+        /// Retrieve the script content, this is not expected to be escaped
+        /// </summary>
+        [Test]
+        public void SvgDocumentWithSvgScript_RetrieveScriptContent_ScriptContentIsNotEscaped()
+        {
             Assert.Inconclusive();
         }
 
+        /// <summary>
+        /// Try to add a script to a document and check if the content was added correctly
+        /// and escaped as expected.
+        /// </summary>
         [Test]
-        public void SvgDocument_AddScript_AddScriptWithEscapingToSvg()
+        public void SvgDocumentWithSvgScript_AddScript_EscapintIsAdded()
         {
             //Script is expected to be escaped
             Assert.Inconclusive();
         }
 
+        /// <summary>
+        /// Test if altering a script (reading, changing and reinserting) does not yield odd results.
+        /// </summary>
         [Test]
-        public void SvgDocument_AlterScriptTag_HandlesEscapingCorrectly()
+        public void SvgDocumentWithSvgScript_AlterScriptTag_HandlesEscapingCorrectly()
         {
             //Expecting to get the script without CDATA
             //After update expect the updated script with CDATA in the results

--- a/Tests/Svg.UnitTests/SvgJavascriptTests.cs
+++ b/Tests/Svg.UnitTests/SvgJavascriptTests.cs
@@ -76,21 +76,21 @@ namespace Svg.UnitTests
         /// and escaped as expected.
         /// </summary>
         [Test]
-        public void SvgDocumentWithSvgScript_AddScript_EscapintIsAdded()
+        public void SvgDocumentWithSvgScript_AddScript_EscapeAndTypeAdded()
         {
             //Script is expected to be escaped
-            Assert.Inconclusive();
-        }
+            var doc = new SvgDocument();
+            var script = new SvgScript();
+            script.Script = "alert('test');";
+            script.ScriptType = "text/javascript";
+            doc.Children.Add(script);
+            var docStr = doc.GetXML();
 
-        /// <summary>
-        /// Test if altering a script (reading, changing and reinserting) does not yield odd results.
-        /// </summary>
-        [Test]
-        public void SvgDocumentWithSvgScript_AlterScriptTag_HandlesEscapingCorrectly()
-        {
-            //Expecting to get the script without CDATA
-            //After update expect the updated script with CDATA in the results
-            Assert.Inconclusive();
+            //Check if we found the type string and CDATA tags
+            Assert.IsFalse(string.IsNullOrWhiteSpace(docStr), "Expected document to be returned");
+            Assert.IsTrue(docStr.IndexOf("<script type=\"text/javascript\">") > -1, "Expected to find the script with type tag");
+            Assert.IsTrue(docStr.IndexOf("<![CDATA[") > -1, "Expected to find the CDATA start");
+            Assert.IsTrue(docStr.IndexOf("]]>") > -1, "Expected to find the CDATA ending");
         }
     }
 }

--- a/Tests/Svg.UnitTests/SvgJavascriptTests.cs
+++ b/Tests/Svg.UnitTests/SvgJavascriptTests.cs
@@ -1,0 +1,55 @@
+using NUnit.Framework;
+using System.IO;
+using System.Linq;
+using System.Xml;
+using System.Collections.Generic;
+
+namespace Svg.UnitTests
+{
+    /// <summary>
+    /// Testing the capabilities to handle SVG documents with Javascript and the option to add
+    /// scripts to the SVG document.
+    /// </summary>
+    [TestFixture]
+    public class SvgJavascriptTests : SvgTestHelper
+    {
+        protected override string TestResource { get { return GetFullResourceString("ScriptTag.TestFile.svg"); } } 
+
+        [Test]
+        public void SvgDocument_ReadFileWithScript_YieldsNoError()
+        {
+            //Expect to read a document with JS without problem
+            var doc = SvgDocument.Open(GetXMLDocFromResource(TestResource));
+            Assert.IsNotNull(doc);
+            var circleElement = doc.Children.FirstOrDefault(c => c.ElementName == "circle");
+            Assert.IsNotNull(circleElement, "Expected to find the circle element in the document");
+            Assert.IsAssignableFrom(typeof(SvgCircle), circleElement, "Expected the found circle element to be of type SvgCircle");
+            
+            var scriptElement = doc.Children.FirstOrDefault(c => c.ElementName == "script");
+            Assert.IsNotNull(scriptElement, "Expected to find the script element in the document");
+            Assert.IsAssignableFrom(typeof(SvgScript), scriptElement, "Expected the found script element to be of type SvgScript");            
+        }
+
+        [Test]
+        public void SvgDocument_FileWithScript_CanRetrieveScriptTag()
+        {
+            //Expected to retrieve the script tag(s) from the document
+            Assert.Inconclusive();
+        }
+
+        [Test]
+        public void SvgDocument_AddScript_AddScriptWithEscapingToSvg()
+        {
+            //Script is expected to be escaped
+            Assert.Inconclusive();
+        }
+
+        [Test]
+        public void SvgDocument_AlterScriptTag_HandlesEscapingCorrectly()
+        {
+            //Expecting to get the script without CDATA
+            //After update expect the updated script with CDATA in the results
+            Assert.Inconclusive();
+        }
+    }
+}

--- a/Tests/Svg.UnitTests/SvgJavascriptTests.cs
+++ b/Tests/Svg.UnitTests/SvgJavascriptTests.cs
@@ -59,12 +59,16 @@ namespace Svg.UnitTests
         }
 
         /// <summary>
-        /// Retrieve the script content, this is not expected to be escaped
+        /// Retrieve the script content, this is not expected to be escaped. CDATA is handled by the SVG parser and should result in a "clean" script.
         /// </summary>
         [Test]
         public void SvgDocumentWithSvgScript_RetrieveScriptContent_ScriptContentIsNotEscaped()
         {
-            Assert.Inconclusive();
+            var doc = SvgDocument.Open(GetXMLDocFromResource(TestResource));
+            Assert.IsNotNull(doc);
+            
+            var tag = GetScriptElementFromDocument(doc);
+            Assert.IsTrue(tag.Script.IndexOf("[DATA") < 0, "CDATA should not be in the content of the script");
         }
 
         /// <summary>


### PR DESCRIPTION
#### Reference Issue
Should address #167 which requests the addition of script tags.

#### What does this implement/fix? Explain your changes.
Allows the creation of SvgScript in the SVG document and can parse the script tags in a SVG file in a type-safe way. Adding of SvgScript was already possible in the past by using a generic tag, having a typed tag for scripts will make handling scripts easier.

Included test cases to test behavior of the script tag on reading and outputting.