### PR TITLE
Add classes that inherits SvgElement to DeepCopy test.

### DIFF
--- a/Tests/Svg.UnitTests/SvgElementDeepCopyTest.cs
+++ b/Tests/Svg.UnitTests/SvgElementDeepCopyTest.cs
@@ -41,6 +41,9 @@ namespace Svg.UnitTests
             CheckDeepCopyInstance(new SvgMerge());
             CheckDeepCopyInstance(new SvgMergeNode());
             CheckDeepCopyInstance(new SvgOffset());
+            CheckDeepCopyInstance(new SvgColourServer());
+            CheckDeepCopyInstance(new SvgDeferredPaintServer());
+            CheckDeepCopyInstance(new SvgFallbackPaintServer());
             CheckDeepCopyInstance(new SvgGradientStop());
             CheckDeepCopyInstance(new SvgLinearGradientServer());
             CheckDeepCopyInstance(new SvgMarker());


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->

Add the following classes.

- SvgColourServer
- SvgDeferredPaintServer
- SvgFallbackPaintServer

#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
