### PR TITLE
Added documentation generation using docfx

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SVG.NET [![NuGet version](https://badge.fury.io/nu/svg.svg)](https://badge.fury.io/nu/svg)
+# SVG.NET [![NuGet version](https://badge.fury.io/nu/svg.svg)](https://badge.fury.io/nu/svg) [![Gitter](https://badges.gitter.im/vvvv/SVG.svg)](https://gitter.im/vvvv/SVG?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 Public fork of the C# SVG rendering library on codeplex: https://svg.codeplex.com/
 
@@ -7,10 +7,7 @@ This started out as a minor modification to enable the writing of proper SVG str
 So please feel free to fork it and open pull requests for any fix, improvement or feature you add. 
 You may check the [contributing guide](https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md) for more information on how to do this. 
 
-For instructions on how to install and use the library, please check the [Getting Started](https://github.com/vvvv/SVG/wiki/Getting-started) guide.
-
-Changes in the latest released versions and in master you can find in the 
-[Release notes](https://github.com/vvvv/SVG/wiki/Release-Notes).
+For information on installation and usage of the library, and for release notes please check the [documentation pages](http://vvvv.github.io/SVG/).
 
 ## Projects using the library
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,7 +53,7 @@ after_build:
         CD _site
         git add -A 2>&1 > $null
         git commit -m "CI Updates" -q
-        git push origin gh-pages -q
+        # git push origin gh-pages -q
     }
 
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,9 +2,20 @@ version: '{build}'
 
 image: Visual Studio 2019
 
+environment:
+  access_token:
+    secure: OitFIZFJWjmB3sDhTYHjgYNXwxX0iWYxib1LfDFlGq/Cos8H1jtBgwgolpi/ek6f
+
 before_build:
 - ps: nuget restore Source\Svg.csproj
 - ps: nuget restore Tests\Svg.UnitTests\Svg.UnitTests.csproj
+- ps: nuget install NUnit.ConsoleRunner -Version 3.10.0 -OutputDirectory tools  
+- ps: |
+    if(-Not $env:APPVEYOR_PULL_REQUEST_TITLE)
+    {
+        git checkout $env:APPVEYOR_REPO_BRANCH -q
+        choco install docfx -y
+    }
 
 branches:
   only:
@@ -22,6 +33,28 @@ configuration: Release
 
 build:
   project: Source\Svg.sln
+
+after_build:
+- ps: |
+    if(-Not $env:APPVEYOR_PULL_REQUEST_TITLE)
+    {
+        docfx docfx.json
+        if ($lastexitcode -ne 0){
+          throw [System.Exception] "docfx build failed with exit code $lastexitcode."
+        }
+        
+        git config --global credential.helper store
+        git config --local core.autocrlf true
+        Add-Content "$env:USERPROFILE\.git-credentials" "https://$($env:access_token):x-oauth-basic@github.com`n"
+        git config --global user.email $env:mrbean-bremen@noreply.com
+        git config --global user.name $env:mrbean-bremen
+        git clone https://github.com/mrbean-bremen/SVG.git -b gh-pages origin_site -q
+        Copy-Item origin_site/.git _site -recurse
+        CD _site
+        git add -A 2>&1 > $null
+        git commit -m "CI Updates" -q
+        git push origin gh-pages -q
+    }
 
 artifacts:
 - path: 'Source\bin\Release\*.nupkg'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,9 +46,9 @@ after_build:
         git config --global credential.helper store
         git config --local core.autocrlf true
         Add-Content "$env:USERPROFILE\.git-credentials" "https://$($env:access_token):x-oauth-basic@github.com`n"
-        git config --global user.email $env:mrbean-bremen@noreply.com
-        git config --global user.name $env:mrbean-bremen
-        git clone https://github.com/mrbean-bremen/SVG.git -b gh-pages origin_site -q
+        git config --global user.email $env:tebjan@noreply.com
+        git config --global user.name $env:tebjan
+        git clone https://github.com/vvvv/SVG.git -b gh-pages origin_site -q
         Copy-Item origin_site/.git _site -recurse
         CD _site
         git add -A 2>&1 > $null

--- a/doc/GettingStarted.md
+++ b/doc/GettingStarted.md
@@ -1,0 +1,80 @@
+## Getting the library
+
+Depending on the way you want to work with the library you can consume the SVG library through Nuget, or roll your own binary from the sources or a personal fork of the sources. 
+
+### Which version to choose?
+There are 2 major supported versions at the moment. A version 2.4.* and a version 3.0.*. The 2.4.* is a .NET Framework specific version (non .NET Core compatible) which can be considered rather stable for use within a .NET project. The 3.0 version is a more recent version with added .NET Core compatibility and the possibility to run the package in .NET Core projects on Windows, Linux and Mac. The .NET framework compatibility is also maintained, which allows you to use the package in the regular .NET framework (version 3.5 and above). The 3.0 version also contains some bugfixes which are not (yet) in the 2.4 version, but this is a limited set and if required these fixes can be merged into the 2.4 version on request.
+
+If you are going to use the package for the first time, your best bet is to go for the 3.0 version, this allows you for maximum flexibility and portability. If you are already using version 2.4 or use other libraries depending on the 2.4 versions you can also upgrade, but there is a possibility that you might encounter compatibility issues/errors. The library is under unit-tests, but a 100% guaranteed equality between the 3.0 and 2.4 versions cannot be given. If you are working with the .NET framework version you are likely to encounter no big issues, but if you switch to the .NET core version or switch platforms (e.g. to Mac or Linux) you need to test and validate the calling code to be sure everything keeps working as expected.
+
+### Installing through Nuget
+The library is available as Nuget in the public nuget feed (https://www.nuget.org/packages/Svg/). Depending on your development stack you can add it to your code base.
+
+For Visual Studio 2013 - 2019 you can add it by searching it in the Nuget wizard or by using the following command in the Nuget Console.
+```
+Install-Package Svg
+```
+
+When using the dotnet-cli, Visual Studio Code or other editors you can add the package to your solution by running the following command in the terminal/console:
+```
+dotnet add package Svg
+```
+
+If you would like to add a specific version you can add the --version parameter in your command or pick a specific version in the wizard. If you want to use pre-release versions in Visual Studio you need to check the box regarding pre-release packages to be able to select pre-release versions.
+
+### Rolling your own version
+If you would like to roll your own version you can download the sources through GitHub, clone the repository to your local machine or create a fork in your own account and download/clone this to your machine. This will give you more flexibility in choosing the target framework(s) and compiler flags.
+
+Once you downloaded the sources you can use the IDE of your choice to open the solution file (Svg.sln) or the Svg library project (Svg.csproj) and use your IDE to compile the version you would like to have.
+
+If you would like to use the dotnet-cli to build the sources you can use the following command in the Sources/ folder to build the library for .NET Core 2.2 with the compiler setting for release:
+```
+dotnet build -c release -f netcoreapp2.2 Svg.csproj
+```
+This will put the output in the bin/Release/netcoreapp2.2/ folder.
+
+## Special instructions for Mac and Linux
+The library depends on GDI+ (see: https://github.com/vvvv/SVG/wiki/Q&A#im-getting-a-svggdipluscannotbeloadedexception-if-running-under-linux-or-macos) for rendering. .NET Core does not support GDI+ out of the box for non-Windows systems. For Mac and Linux you need to add a special compatibility package. This is not included by default in the packages, since this will break rendering on Windows systems.
+
+I you distribute your application as platform independent you might want to add the following instructions (or a reference to this guide) in your installation instructions to aid Mac and Linux users that want to utilize your application/library.
+
+### Linux (Ubuntu)
+For Linux you need to install libgdiplu from the quamotion/ppa feed on your machine/container:
+```
+sudo add-apt-repository ppa:quamotion/ppa
+sudo apt-get update
+sudo apt-get install -y libgdiplus
+```
+
+### MacOs
+Mac does not require you to install a system-wide package, but allows you to use a compatibility package that is included in the application. This package can be included in the SVG component if you roll your own version from source, this can be achieved by altering the Svg.csproj file and un-comment the following block of code:
+```
+<!-- 
+<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.2'">
+  <PackageReference Include="runtime.osx.10.10-x64.CoreCompat.System.Drawing" Version="5.8.64" />
+</ItemGroup> 
+-->
+```
+This will link the CoreCompat package in the project, if you make a project reference to the Svg.csproject the consuming application/library will automatically also include the CoreCompat package.
+
+If you are not building from the source or do not want to make the Svg library dependent on the CoreCompat package you can add the reference in the "ultimate" consumer of the package (the application that will be executed), by the following command in a terminal/console within the consuming application folder:
+```
+dotnet add package runtime.osx.10.10-x64.CoreCompat.System.Drawing
+```
+
+## Linking the library in your application
+If you installed or build the library, it's time to add it to your application. If you used the Nuget approach, the reference should already be set correctly (please note that for Mac and Linux the compatibility tooling/package needs to be done manually).
+
+If you rolled your own version you can link the .csproj to your own project via your IDE. If you want to do it through the dotnet-cli you can run:
+```
+dotnet add reference SVG/sources/Svg.csproj
+```
+(where SVG is the root folder you downloaded the sources to). This approach will also take over all references required to the target project (e.g. when you added the corecompat package for Mac). This will also compile the Svg sources when you build your own project, which might be useful if you plan to make changes in the Svg project yourself.
+
+If you don't want to reference the project, you can get the Svg.dll file from the outpot folders after you compiled the project with the steps outlined above and reference the Svg.dll file. The Svg library does not utilize other external references and by only using the Svg.dll file you will be able to use the library. However please keep in mind that the Mac and Linux versions require additional tooling/packages.
+
+## Using the library (examples)
+This part will be extended in the future, for now please refer to the Q&A for examples of how to use the library: https://github.com/vvvv/SVG/wiki/Q&A
+
+## Troubleshooting
+If you encounter any problems or difficulties, please refer to the Q&A part of the wiki (https://github.com/vvvv/SVG/wiki/Q&A). If the Q&A does not solve your problem, please open a ticket with your request.

--- a/doc/Q&A.md
+++ b/doc/Q&A.md
@@ -1,0 +1,150 @@
+This is currently a collection of answered questions in issues that have been closed meanwhile.
+The format of the page is preliminary and maybe changed if more questions accumulate.
+
+## How to get started
+Please use our getting started article on the wiki to get started with installation and implementation of the SVG library: https://github.com/vvvv/SVG/wiki/Getting-started
+
+## How to re-render an SVG faster?
+
+(from [#327](https://github.com/vvvv/SVG/issues/327), by @flemingtech)
+
+The rendering type plays a significant roll on rendering speeds. For example, it anti-aliasing is off for the SvgDocument render times are notably faster.
+
+Because of the huge reduction in image quality, this wasn't a viable solution for my needs. Instead what I've come up with so far seems to work since I can't figure out how to get clipping regions to work.
+
+After I load the SVG, I make new SVG with the same initial SvgDocument properties (basically a deep copy followed by deleting all children). As I walk the first document tree I'm looking for elements I know are going to be modified. For each one that I find, I remove it from the first SVG and put it into the 2nd SVG. When I'm doing this, I also apply any parent transforms to the new child since it doesn't need/have all of it's parents.
+
+Once I'm done, I render the first SVG to an Image. When any of the 'animating' elements are changed, the 2nd SVG is rendered on top of a copy of the first SVG's rendering to form a complete composite. This prevents all the non-moving elements for having to re-render, unless of course the target graphics width/height changes. This is giving huge performance gains.
+
+## Can I use SVG.NET in a UWP Windows 10 App?
+
+(from [#219](https://github.com/vvvv/SVG/issues/219), by @jonthysell)
+
+SVG.NET requires the System.Drawing namespace, which is not available in UWP. See http://stackoverflow.com/questions/31545389/windows-universal-app-with-system-drawing-and-possible-alternative.
+
+## How to render an SVG image to a single-color bitmap image?
+
+(from [#366](https://github.com/vvvv/SVG/issues/366), by @UweKeim)
+
+I was able to find a solution with the following fragment:
+
+```csharp
+var svgDoc = SvgDocument.Open<SvgDocument>(svgFilePath, null);
+
+// Recursively change all nodes.
+processNodes(svgDoc.Descendants(), new SvgColourServer(Color.DarkGreen));
+
+var bitmap = svgDoc.Draw();
+```
+
+together with this function:
+
+```csharp
+private void processNodes(IEnumerable<SvgElement> nodes, SvgPaintServer colorServer)
+{
+    foreach (var node in nodes)
+    {
+        if (node.Fill != SvgPaintServer.None) node.Fill = colorServer;
+        if (node.Color != SvgPaintServer.None) node.Color = colorServer;
+        if (node.StopColor != SvgPaintServer.None) node.StopColor = colorServer;
+        if (node.Stroke != SvgPaintServer.None) node.Stroke = colorServer;
+
+        processNodes(node.Descendants(), colorServer);
+    }
+}
+```
+
+## How to render only a specific SvgElement?
+
+(from [#403](https://github.com/vvvv/SVG/issues/403), by @ievgennaida)
+
+Use `element.RenderElement();`.
+
+## How to render an SVG document to a bitmap in another size?
+
+Use `SvgDocument.Draw(int rasterWidth, int rasterHeight)`. If one of the values is 0, it it set to preserve the aspect ratio, if both values are given, the aspect ratio is ignored.
+
+## Is this code server-safe?
+
+(from [#381](https://github.com/vvvv/SVG/issues/381), by @rangercej, answered by @gvheertum)
+
+I used it in server side code (ASP.NET MVC application and API's) and never had any problems with it. There is however be possible issues regarding use in services and API's, for example the System.Drawing might not always be available in certain situations (if I am not mistaken, some Azure service will not provide the System.Drawing since it relies on GDI calls) and will also be an issue when using it as "portable" code for example in .NET standard or .NET core (but I believe the library is already working on a migration/compatibility with .NET core/standard).
+
+So issues when using System.Drawing are indeed possible when using in a non interactive scenario, since most non-interactive code will often be functioning as service or API, meaning a lot of synchronous calls are possible, which opens a world of possible problems compared to an interactive app which you often only have a few instances loaded. System.Drawing can (and often will) be resource-heavy, so having a lot of synchronous processes will possibly have a huge impact on the performance. So I guess, that is why Microsoft warns about the usage. Rendering a large complex SVG to a big bitmap (eg 5000x5000px) will put a large load on the server, doing this in parallel might cause issues in performance and availability.
+
+System.Drawing was initially not really created for service usage, so you *can* use it, but really need to be aware of possible issues. For example, see this article: https://photosauce.net/blog/post/5-reasons-you-should-stop-using-systemdrawing-from-aspnet
+
+I believe there are some parallelisation tests in the UnitTest suite, since the SVG component did have some concurrency issues in the past. The parallelisation tests show that some parallel work is possible, but upping the limit will show you that resource issues are to be expected under large loads. When failing, System.Drawing will often not fail gracefully, but will often crash with some meaningless error (which makes debugging pretty hard sometimes).  
+
+## How to change the SvgUnit DPI?
+
+(from [#313](https://github.com/vvvv/SVG/issues/313), by @KieranSmartMP)
+
+`SvgUnit` takes the DPI (which is called `Ppi` here) from the document. This is set to the system DPI at creation time, but can be set to another value afterwards, e.g. 
+```c#
+  doc = SvgDocument();
+  doc.Ppi = 200;
+  ...
+```
+
+## Why does my application crash with "cannot allocate the required memory"?
+
+(from [#250](https://github.com/vvvv/SVG/issues/250), by @Radzhab)
+
+If you try to open a very large SVG file in your application, it may crash, because .NET refuses to allocate that much contiguous memory, even if it could do so in theory. This is done to avoid processes to consume too much memory and slow down the system. Nothing we can do about this - you may catch this exception in your application and inform the user, or try to resize your SVG document and retry.
+
+## How to add a custom attribute to an SVG element?
+
+(from [#481](https://github.com/vvvv/SVG/issues/481), by @lroye)
+
+Custom attributes are publicly accessible as a collection, you can add an attribute like this:
+```C#
+    element.CustomAttributes[attributeName] = attributeValue;
+```
+
+## I'm getting a SvgGdiPlusCannotBeLoadedException if running under Linux or MacOs
+
+(see [#494](https://github.com/vvvv/SVG/pull/495#issuecomment-505429874), by @ErlendSB)
+
+This happens if libgdiplus is not installed under Linux or MacOs - libgdiplus is need for the implementation of System.Drawing.Common. The system will validate gdi+ capabilities when calling SvgDocument.Open(), if the gdi+ capabilities are not available, you will receive a SvgGdiPlusCannotBeLoadedException. 
+
+There is a [packaging project on Github](https://github.com/CoreCompat/libgdiplus-packaging) that helps installing that, here are the installation instructions (copied here for convenience):
+
+Older versions of the package threw a NullReferenceException when calling the SvgDocument.Open function. The cause of these errors was the same. Newer releases (since version 3.0), will yield a more descriptive exception as described above.
+
+### Using libgdiplus on Ubuntu Linux
+
+You can install libgdiplus on Ubuntu Linux using the Quamotion PPA. Follow these steps:
+```
+sudo add-apt-repository ppa:quamotion/ppa
+sudo apt-get update
+sudo apt-get install -y libgdiplus
+```
+### Using libgdiplus on macOS
+
+On macOS, add a reference to the runtime.osx.10.10-x64.CoreCompat.System.Drawing package:
+
+```dotnet add package runtime.osx.10.10-x64.CoreCompat.System.Drawing```
+
+When building from source-code you can also uncomment the 
+```
+<!-- <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.2'">
+    <PackageReference Include="runtime.osx.10.10-x64.CoreCompat.System.Drawing" Version="5.6.20" />
+  </ItemGroup> -->
+``` 
+block in the Svg.csproj file.
+
+### Validating GDI+ capabilities
+
+If you want to make sure the executing system is capable of using the GDI+ features, you can use one of the functions available on the SvgDocument class.
+
+If you only want to get a boolean telling whether the capabilities are available, please use the following code:
+```
+bool hasGdiCapabilities = SvgDocument.SystemIsGdiPlusCapable();
+```
+
+If you want to ensure the capabilities and let an error be thrown when these are not available, please use the following code:
+```
+SvgDocument.EnsureSystemIsGdiPlusCapable();
+```
+This function will throw a SvgGdiPlusCannotBeLoadedException if the capabilities are not available.

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -1,0 +1,143 @@
+# SVG.NET Release Notes
+The release versions are NuGet releases.
+
+## Unreleased (master)
+
+**Note:** this is the first version that supports .NET Core alongside .NET.
+To build it yourself, you need at least Visual Studio 2017 due to the added multi-platform support.
+
+### Enhancements
+* added support for .NET Core 2.2 (see PR [#448](https://github.com/vvvv/SVG/pull/448))
+* handle missing gdi+ library on MacOs or Linux by a descriptive exception (see [#501](https://github.com/vvvv/SVG/issues/501))
+* allow ID start with a number (see [#138](https://github.com/vvvv/SVG/issues/138))
+* added support for embedded SVG in data URIs (see [#71](https://github.com/vvvv/SVG/issues/71)
+  and [#220](https://github.com/vvvv/SVG/issues/220))
+* support `auto-start-reverse` value for marker orientation (see PR [#458](https://github.com/vvvv/SVG/pull/458)) 
+
+### Infrastructure
+* use NUnit instead of MSTest for unit tests (see [#420](https://github.com/vvvv/SVG/issues/420))
+* added automatic git versioning
+
+### Documentation
+* added "Getting Started" Wiki page
+
+### Fixes
+* avoid adding a null system font (see [#528](https://github.com/vvvv/SVG/issues/528))
+* fixed missing text drawing (see [#84](https://github.com/vvvv/SVG/issues/84))
+* fixed y2 default value for SvgLinearGradientServer (see [PR #530](https://github.com/vvvv/SVG/pull/530))
+* fixed incorrect parsing of some float values for non-English cultures
+  (see [PR #525](https://github.com/vvvv/SVG/pull/525) and [#526](https://github.com/vvvv/SVG/pull/526))
+* fixed pattern drawing (see [#280](https://github.com/vvvv/SVG/issues/280))
+* prevent crash on reading entities (see [#518](https://github.com/vvvv/SVG/issues/518))
+* fixed saving of attributes with default value (see [PR #520](https://github.com/vvvv/SVG/pull/520))
+* fixed determination of OS type (see [PR #517](https://github.com/vvvv/SVG/pull/517))
+* fixed writing of custom style attributes (see [#507](https://github.com/vvvv/SVG/issues/507))
+* handle overlapping caps by joining the lines (see [#508](https://github.com/vvvv/SVG/issues/508))
+* correctly handle style attributes in top level svg element (see [#391](https://github.com/vvvv/SVG/issues/391))
+* fixed incorrect rendering if stroke-dasharray value is none (see [PR #504](https://github.com/vvvv/SVG/pull/504))
+* prevent exception for zero bounds and opacity not one (see [#479](https://github.com/vvvv/SVG/issues/479))
+* make sure mask elements are written back to svg (see [#271](https://github.com/vvvv/SVG/issues/271))
+* fixed incorrect clip region (see [#363](https://github.com/vvvv/SVG/issues/363))
+* fixed overflow error on 1 character text with tspan (see [#488](https://github.com/vvvv/SVG/issues/488))
+* fixed crash with unsupported pseudo classes (see [#315](https://github.com/vvvv/SVG/issues/315))
+* fixes wrong text position in some scenarios (see PR [#475](https://github.com/vvvv/SVG/pull/475))
+* fixed handling of spaces for `xml:space="default"` (see PR [#471](https://github.com/vvvv/SVG/pull/471))
+* fixed crash if more than font have the same name (see [#452](https://github.com/vvvv/SVG/issues/452))
+* fixed rendering bug for text on path using very large font
+  (see PR [#468](https://github.com/vvvv/SVG/pull/468))
+* avoid exception in nested SVGs without size (see [#460](https://github.com/vvvv/SVG/issues/460))
+* fixed default input values for filter primitives
+* fixed parsing of float values in color matrixes and colors on non-English systems
+* fixed xlink:href value format (see PR [#455](https://github.com/vvvv/SVG/pull/455))
+* support various formats of URL string (see PR [#454](https://github.com/vvvv/SVG/pull/454))
+* fixed stack overflow crash on images with relative size 
+  (see [#436](https://github.com/vvvv/SVG/issues/436))
+
+## [Version 2.4.3](https://www.nuget.org/packages/Svg/2.4.3)
+### Fixes
+* fixed boundary drawing with corner and stroke (see PR [#444](https://github.com/vvvv/SVG/pull/444))
+* fixed rendering with fill opacity 0 (see [#437](https://github.com/vvvv/SVG/issues/437))
+* fixed opacity attribute (see PR [#433](https://github.com/vvvv/SVG/pull/433))
+* fixed bounds calculation with stroke (see PR [#433](https://github.com/vvvv/SVG/pull/433))
+
+## [Version 2.4.2](https://www.nuget.org/packages/Svg/2.4.2)
+### Enhancements
+* added font manager to allow user-defined font handling 
+  (see PR [#414](https://github.com/vvvv/SVG/pull/414)) 
+
+### Fixes
+* fixed handling of invalid hex color and whitespace after hex color (see [#399](https://github.com/vvvv/SVG/issues/399))
+* fixed default font size (caused text not to be displayed, see [#419](https://github.com/vvvv/SVG/issues/419))
+* fixed writing of RGBA colors (see [#129](https://github.com/vvvv/SVG/issues/129))
+* fixed writing of custom styles (see [#129](https://github.com/vvvv/SVG/issues/129))
+* fixed handling of default values for radial gradients (see [#397](https://github.com/vvvv/SVG/issues/397))
+* allow empty value for style property (see [#318](https://github.com/vvvv/SVG/issues/318))
+* added handling of referenced viewBox scaling in "use" elements 
+* handle special case where path consists of a single move command 
+  (see [#223](https://github.com/vvvv/SVG/issues/223))
+* correctly write fill-rule, clip-rule and named color attributes as lower case
+  (see [#272](https://github.com/vvvv/SVG/issues/272))
+* several fixes for markers:
+  * added support for marker attributes in groups
+  * partly fixed marker appearance (stroke and fill color, scaling, deafult orientation)
+  * apply transformations in the marker drawing element (see [#215](https://github.com/vvvv/SVG/issues/215))
+  * correctly show mid markers for paths with Bezier curves
+  * handle markers on paths with successive equal points
+
+## [Version 2.4.1](https://www.nuget.org/packages/Svg/2.4.1)
+### Changes
+* `ExCSS` lives now in the `Svg` namespace to avoid namespace collusions 
+  (see [#408](https://github.com/vvvv/SVG/issues/408))
+
+### Fixes
+* fixed handling of url IDs enclosed in apostrophes (see [#345](https://github.com/vvvv/SVG/issues/345)) 
+* fixed calculation of percentage values (PR [#410](https://github.com/vvvv/SVG/pull/410))
+* regression: missing scaling if rendering into a bitmap with defined size 
+  (see [#405](https://github.com/vvvv/SVG/issues/405))
+* consider transformation for all svg element bounds (see [#331](https://github.com/vvvv/SVG/issues/331))
+* prevent crash if `use` element has no reference (see [#323](https://github.com/vvvv/SVG/issues/323))
+* fixed handling of `fill=currentColor` (see [#398](https://github.com/vvvv/SVG/issues/398))
+
+## [Version 2.4.0](https://www.nuget.org/packages/Svg/2.4.0)
+
+### Enhancements
+  * added basic support for CSS text-transform 
+  * added optional size parameter to `SvgDocument.Draw()`
+  * allow relative paths for image URLs
+  * improved path drawing performance
+  * added XML Header to conform according to SVG spec ([PR #269](https://github.com/vvvv/SVG/pull/269))
+  * added support for removing Byte Order Mark (BOM) ([PR #269](https://github.com/vvvv/SVG/pull/269))
+
+### Infrastructure
+  * added copy of license
+  * added automatic unit test execution after check-in in AppVeyor
+
+### Fixes
+  * fixed display of rounded caps for dashed lines using dasharray (see [#191](https://github.com/vvvv/SVG/issues/191))
+  * fixed calculation of percentage units in 'y' (see [#329](https://github.com/vvvv/SVG/issues/329))
+  * fixed calculation of percentage units in `stroke-width` (see [#338](https://github.com/vvvv/SVG/issues/338))
+  * fixed display of `dasharray` with odd number (see [#58](https://github.com/vvvv/SVG/issues/58))
+  * fixed font alignment for "middle" and "end" (see [#385](https://github.com/vvvv/SVG/issues/385))
+  * fixed handling of `stroke-dashoffset` (see [#388](https://github.com/vvvv/SVG/issues/388))
+  * fixed font shorthand parsing
+  * fixed case insensitive enum parsing
+  * ignore cycles in `use` elements to prevent crash
+  * fixes bounds calculation for `use` elements
+  * corrected DPI calculation to fix text positioning for printing 
+  * ignore `textLength` attribute if X attribute is list
+  * fixed drawing of SvgFont objects
+  * fixed adjustment if `lengthAdjust='spacingAndGlyphs'` (see [#373](https://github.com/vvvv/SVG/issues/373))
+  * fixed SvgAttribute reflection for .Net core
+  * fixed default value for `preserveAspectRatio` attribute 
+  * fixed path parsing mistaking 'E' as a command instead of an exponent
+  * fixed image opacity
+  * fixed usage of `ms colortranslator` class
+  * fixed inproper use of UTF8Encoding
+  * fixed runtime error after accessing added `SvgText` element (see [#332](https://github.com/vvvv/SVG/issues/332)) 
+  * fixed rendering error due to invalid `ColorBlend` position
+  * fixed inheriting `text-anchor` and `baseline-shift` attributes
+  * prevent crashes on zero length segments or paths
+  * fixed handling of nested SVGs (see [#244](https://github.com/vvvv/SVG/issues/244))
+  * fixed crash in `use` elements with transformation (see [#64](https://github.com/vvvv/SVG/issues/64)) 
+  * fixed overflow handling for view boxes (see [#279](https://github.com/vvvv/SVG/issues/279))
+  * bounds in path based elements did not consider transformations (see [#281](https://github.com/vvvv/SVG/issues/281))

--- a/docfx.json
+++ b/docfx.json
@@ -1,0 +1,33 @@
+{
+  "metadata": [
+    {
+      "src": [
+        {
+          "files": [ "**/*.cs" ],
+          "exclude": [ "**/bin/**", "**/obj/**", "External/**" ],
+          "src": "Source"
+        }
+      ],
+      "dest": "obj/api"
+    }
+  ],
+  "build": {
+    "content": [
+      {
+        "files": [ "**/*.yml" ],
+        "src": "obj/api",
+        "dest": "api"
+      },
+      {
+        "files": [ "*.md", "doc/*.md" ]
+      }
+    ],
+    "globalMetadata": {
+      "_appTitle": "SVG.NET API",
+      "_enableSearch": true
+    },
+    "markdownEngineName": "markdig",
+    "dest": "_site",
+    "xrefService": [ "https://xref.docs.microsoft.com/query?uid={uid}" ]
+  }
+}

--- a/index.md
+++ b/index.md
@@ -1,0 +1,15 @@
+# SVG.NET Documentation
+
+Welcome to the documentation for the SVG.NET library!
+
+### Usage documentation
+- [Getting Started](doc/GettingStarted.html)
+- [Q&A](doc/Q&A.html)
+- [Generated API documentation](api/toc.html)
+  
+### Project documentation
+- [Release Notes](doc/ReleaseNotes.html)
+- [Contributing Guide](CONTRIBUTING.html)
+
+_Note that this documentation is work in progress.
+You are always welcome to help improving it!_


### PR DESCRIPTION
- added generated API doc
- added documentation from Wiki

This is a first try at generating GitHub Pages documentation. I added generated API doc, and copied the Wiki pages over.
This currently only works in my branch due to permission issues.

@tebjan - to get this to work in master, you need to generate a personal GitHub access token with public repo access (GitHub settings / Developer settings / Personal access tokens), encrypt it using [Appveyor](https://ci.appveyor.com/tools/encrypt), and replace the current token in appveyor.yml.
You also may have to enable GitHub pages on the repository settings site (options page, scroll down to GitHub Pages, and select "gh-pages branch").
