### PR TITLE
 Do not copy None, Inherit and NotSet at DeepCopy. 

### DIFF
--- a/Source/Painting/SvgColourServer.cs
+++ b/Source/Painting/SvgColourServer.cs
@@ -73,6 +73,9 @@ namespace Svg
 
         public override SvgElement DeepCopy<T>()
         {
+            if (this == None || this == Inherit || this == NotSet)
+                return this;
+
             var newObj = base.DeepCopy<T>() as SvgColourServer;
             newObj.Colour = this.Colour;
             return newObj;

--- a/Tests/Svg.UnitTests/SvgElementDeepCopyTest.cs
+++ b/Tests/Svg.UnitTests/SvgElementDeepCopyTest.cs
@@ -71,6 +71,14 @@ namespace Svg.UnitTests
             Assert.IsInstanceOf<T>(dest);
         }
 
+        [Test]
+        public void TestDoNotDeepCopy()
+        {
+            Assert.AreSame(SvgPaintServer.None, SvgPaintServer.None.DeepCopy());
+            Assert.AreSame(SvgColourServer.Inherit, SvgColourServer.Inherit.DeepCopy());
+            Assert.AreSame(SvgColourServer.NotSet, SvgColourServer.NotSet.DeepCopy());
+        }
+
         /// <summary>
         /// Tests that the deep copy of a <see cref="SvgText"/> is done correctly where the
         /// text element has contains only text and now other elements like <see cref="SvgTextSpan"/>.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->

Do not copy `None`, `Inherit` and `NotSet` at `DeepCopy`. 

#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
