### PR TITLE
Added license details

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,13 @@ Changes in the latest released versions and in master you can find in the
 * [Chordious](http://chordious.com) a fretboard diagram generator for fretted stringed instruments.
 
 If you want your project in this list, send me a pull request on this file or link + short description to tebjan (at) vvvv.org
+
+## License
+Licensed under the MS-PL license.
+
+This project has dependencies on other open-source projects. These projects are referenced via NuGet packages and might be subject to different licenses.
+
+|Project|Author|Sources|License|
+|--------|-----|---|---------|
+|Fizzler|Atif Aziz (@atifaziz)|[GitHub](https://github.com/atifaziz/Fizzler)|[LGPL](https://github.com/atifaziz/Fizzler/blob/master/COPYING.LESSER.txt)|
+|ExCSS|Tyler Brinks (@tylerbrinks)|[GitHub](https://github.com/TylerBrinks/ExCSS)|[MIT](https://github.com/TylerBrinks/ExCSS/blob/master/license.txt)|


### PR DESCRIPTION
#### Reference Issue
Follow-up from #567 regarding mentions/attribution to dependent projects. 

#### What does this implement/fix? Explain your changes.
Added license in the readme and added a list of sub-dependencies with links to the repo's and the licenses. This makes it more clear that there might be sub-dependencies with different licenses. Also this gives credits to the authors, which is nice 🌷 
