### PR TITLE
Make ExCSS library independent.

### DIFF
--- a/Source/Css/CssQuery.cs
+++ b/Source/Css/CssQuery.cs
@@ -40,7 +40,7 @@ namespace Svg.Css
                     // class, pseudo-class, attribute
                     return 1 << 8;
                 }
-                else if (selector == SimpleSelector.All)
+                else if (simpleCode.Equals("*"))
                 {
                     // all selector
                     return 0;


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

Ref. #563.

#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->

Following constant were referenced:

https://github.com/vvvv/SVG/blob/05f54cb5dc2dfe84f6d4d644eb8b378b3c30bc35/Source/External/ExCSS/Model/Selector/SimpleSelector.cs#L10

This is non-public constant for ExCSS.
So I changed it so that it is not referenced.

#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
