### PR TITLE
Add classes that inherits SvgElement to DeepCopy test.

### DIFF
--- a/Source/SvgUnknownElement.cs
+++ b/Source/SvgUnknownElement.cs
@@ -4,24 +4,16 @@ namespace Svg
     {
         public SvgUnknownElement()
         {
-
         }
 
         public SvgUnknownElement(string elementName)
         {
-            this.ElementName = elementName;
+            ElementName = elementName;
         }
 
         public override SvgElement DeepCopy()
         {
             return DeepCopy<SvgUnknownElement>();
-        }
-
-        public override SvgElement DeepCopy<T>()
-        {
-            var newObj = base.DeepCopy<T>() as SvgUnknownElement;
-
-            return newObj;
         }
     }
 }

--- a/Tests/Svg.UnitTests/SvgElementDeepCopyTest.cs
+++ b/Tests/Svg.UnitTests/SvgElementDeepCopyTest.cs
@@ -62,6 +62,8 @@ namespace Svg.UnitTests
             CheckDeepCopyInstance(new SvgTextPath());
             CheckDeepCopyInstance(new SvgTextRef());
             CheckDeepCopyInstance(new SvgTextSpan());
+            CheckDeepCopyInstance(new NonSvgElement());
+            CheckDeepCopyInstance(new SvgUnknownElement());
         }
 
         private void CheckDeepCopyInstance<T>(T src)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->

Add the following classes.

- NonSvgElement
- SvgUnknownElement

#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
