### PR TITLE
Fix: SvgColourServer ToString method.

### DIFF
--- a/Source/Painting/SvgColourServer.cs
+++ b/Source/Painting/SvgColourServer.cs
@@ -53,7 +53,7 @@ namespace Svg
                 return c.Name;
 #endif
             // Return the hex value
-            return String.Format("#{0}", c.ToArgb().ToString("x").Substring(2));
+            return String.Format("#{0}", c.ToArgb().ToString("x8").Substring(2));
         }
 
         public override SvgElement DeepCopy()

--- a/Source/Painting/SvgPaintServerFactory.cs
+++ b/Source/Painting/SvgPaintServerFactory.cs
@@ -81,10 +81,9 @@ namespace Svg
         {
             if (destinationType == typeof(string))
             {
-                // check for none
-                if (value == SvgPaintServer.None) return "none";
-                if (value == SvgPaintServer.Inherit) return "inherit";
-                if (value == SvgPaintServer.NotSet) return string.Empty;
+                // check for constant
+                if (value == SvgPaintServer.None || value == SvgPaintServer.Inherit || value == SvgPaintServer.NotSet)
+                    return value.ToString();
 #if !NETSTANDARD20
                 var colourServer = value as SvgColourServer;
                 if (colourServer != null)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->

Exception occurs with the following code.
```cs
new SvgColourServer(System.Drawing.Color.FromArgb(0)).ToString();
```

This issue occurs with the following test file:

- _issue-436-01.svg
- _issue-437-01.svg

#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
