### PR TITLE
Fix: Number of values in array increases if number of values is odd.

### DIFF
--- a/Source/Basic Shapes/SvgVisualElement.cs
+++ b/Source/Basic Shapes/SvgVisualElement.cs
@@ -282,17 +282,20 @@ namespace Svg
                             {
                                 if (StrokeDashArray != null && StrokeDashArray.Count > 0)
                                 {
-                                    strokeWidth = strokeWidth <= 0 ? 1f : strokeWidth;
-                                    if (StrokeDashArray.Count % 2 != 0)
+                                    var strokeDashArray = StrokeDashArray;
+                                    if (strokeDashArray.Count % 2 != 0)
                                     {
                                         // handle odd dash arrays by repeating them once
-                                        StrokeDashArray.AddRange(StrokeDashArray);
+                                        strokeDashArray = new SvgUnitCollection();
+                                        strokeDashArray.AddRange(StrokeDashArray);
+                                        strokeDashArray.AddRange(StrokeDashArray);
                                     }
-
                                     var dashOffset = StrokeDashOffset;
 
+                                    strokeWidth = Math.Max(strokeWidth, 1f);
+
                                     /* divide by stroke width - GDI uses stroke width as unit.*/
-                                    var dashPattern = StrokeDashArray.Select(u => ((u.ToDeviceValue(renderer, UnitRenderingType.Other, this) <= 0f) ? 1f : 
+                                    var dashPattern = strokeDashArray.Select(u => ((u.ToDeviceValue(renderer, UnitRenderingType.Other, this) <= 0f) ? 1f : 
                                         u.ToDeviceValue(renderer, UnitRenderingType.Other, this)) / strokeWidth).ToArray();
                                     var length = dashPattern.Length;
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->

##### SVG
```svg
<line x1="10" y1="10" x2="180" y2="10" stroke="black" stroke-width="4" stroke-dasharray="20 4 8" />
```

##### Expected

```svg
<line x1="10" y1="10" x2="180" y2="10" stroke="black" stroke-width="4" stroke-dasharray="20 4 8" />
```
##### Actual

```svg
<line x1="10" y1="10" x2="180" y2="10" stroke="black" stroke-width="4" stroke-dasharray="20 4 8 20 4 8" />
```

#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
