### PR TITLE
Fix: If value is 'inherit', stroke-dasharray disappears.

### DIFF
--- a/Source/DataTypes/SvgPointCollection.cs
+++ b/Source/DataTypes/SvgPointCollection.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
+using System.Text;
 
 namespace Svg
 {
@@ -35,13 +33,10 @@ namespace Svg
     }
 
     /// <summary>
-    /// A class to convert string into <see cref="SvgUnitCollection"/> instances.
+    /// A class to convert string into <see cref="SvgPointCollection"/> instances.
     /// </summary>
     internal class SvgPointCollectionConverter : TypeConverter
     {
-        //private static readonly SvgUnitConverter _unitConverter = new SvgUnitConverter();
-
-
         /// <summary>
         /// Converts the given object to the type of this converter, using the specified context and culture information.
         /// </summary>
@@ -52,14 +47,11 @@ namespace Svg
         /// An <see cref="T:System.Object"/> that represents the converted value.
         /// </returns>
         /// <exception cref="T:System.NotSupportedException">The conversion cannot be performed. </exception>
-        public override object ConvertFrom(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value)
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
         {
             if (value is string)
             {
-                var strValue = ((string)value).Trim();
-                if (string.Compare(strValue, "none", StringComparison.InvariantCultureIgnoreCase) == 0) return null;
-
-                var parser = new CoordinateParser(strValue);
+                var parser = new CoordinateParser(((string)value).Trim());
                 var pointValue = 0.0f;
                 var result = new SvgPointCollection();
                 while (parser.TryGetFloat(out pointValue))
@@ -71,25 +63,6 @@ namespace Svg
             }
 
             return base.ConvertFrom(context, culture, value);
-        }
-
-        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
-        {
-            if (destinationType == typeof(string))
-            {
-                return true;
-            }
-            return base.CanConvertTo(context, destinationType);
-        }
-
-        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
-        {
-            if (destinationType == typeof(string))
-            {
-                return ((SvgPointCollection)value).ToString();
-            }
-
-            return base.ConvertTo(context, culture, value, destinationType);
         }
     }
 }

--- a/Source/DataTypes/SvgUnitCollection.cs
+++ b/Source/DataTypes/SvgUnitCollection.cs
@@ -20,7 +20,7 @@ namespace Svg
         /// <summary>
         /// Sets <see cref="None"/> or <see cref="Inherit"/> if needed.
         /// </summary>
-        public string StringIfEmpty { get; set; }
+        public string StringForEmptyValue { get; set; }
 
         public void AddRange(IEnumerable<SvgUnit> collection)
         {
@@ -43,8 +43,8 @@ namespace Svg
 
         public override string ToString()
         {
-            if (Count <= 0 && !string.IsNullOrEmpty(StringIfEmpty))
-                return StringIfEmpty;
+            if (Count <= 0 && !string.IsNullOrEmpty(StringForEmptyValue))
+                return StringForEmptyValue;
 
             // The correct separator should be a single white space.
             // More see:
@@ -114,12 +114,12 @@ namespace Svg
                 if (s.Equals(SvgUnitCollection.None, StringComparison.OrdinalIgnoreCase))
                     return new SvgUnitCollection
                     {
-                        StringIfEmpty = SvgUnitCollection.None
+                        StringForEmptyValue = SvgUnitCollection.None
                     };
                 else if (s.Equals(SvgUnitCollection.Inherit, StringComparison.OrdinalIgnoreCase))
                     return new SvgUnitCollection
                     {
-                        StringIfEmpty = SvgUnitCollection.Inherit
+                        StringForEmptyValue = SvgUnitCollection.Inherit
                     };
             }
 

--- a/Source/DataTypes/SvgUnitCollection.cs
+++ b/Source/DataTypes/SvgUnitCollection.cs
@@ -13,6 +13,13 @@ namespace Svg
     [TypeConverter(typeof(SvgUnitCollectionConverter))]
     public class SvgUnitCollection : ObservableCollection<SvgUnit>
     {
+        public static string None = "none";
+
+        public static string Inherit = "inherit";
+
+        /// <summary>
+        /// Sets <see cref="None"/> or <see cref="Inherit"/> if needed.
+        /// </summary>
         public string StringIfEmpty { get; set; }
 
         public void AddRange(IEnumerable<SvgUnit> collection)
@@ -104,15 +111,15 @@ namespace Svg
             if (value is string)
             {
                 var s = ((string)value).Trim();
-                if (s.Equals("none", StringComparison.OrdinalIgnoreCase))
+                if (s.Equals(SvgUnitCollection.None, StringComparison.OrdinalIgnoreCase))
                     return new SvgUnitCollection
                     {
-                        StringIfEmpty = "none"
+                        StringIfEmpty = SvgUnitCollection.None
                     };
-                else if (s.Equals("inherit", StringComparison.OrdinalIgnoreCase))
+                else if (s.Equals(SvgUnitCollection.Inherit, StringComparison.OrdinalIgnoreCase))
                     return new SvgUnitCollection
                     {
-                        StringIfEmpty = "inherit"
+                        StringIfEmpty = SvgUnitCollection.Inherit
                     };
             }
 

--- a/Source/SvgElementStyle.cs
+++ b/Source/SvgElementStyle.cs
@@ -113,6 +113,7 @@ namespace Svg
             set { Attributes["stroke-miterlimit"] = value; }
         }
 
+        [TypeConverter(typeof(SvgStrokeDashArrayConverter))]
         [SvgAttribute("stroke-dasharray")]
         public virtual SvgUnitCollection StrokeDashArray
         {


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

Ref. #520 and #504.

#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->

##### SVG

```svg
<rect x="10" y="10" width="180" height="180" fill="red" stroke="black" stroke-width="4" stroke-dasharray="inherit" />
```

##### Expected
```svg
<rect x="10" y="10" width="180" height="180" stroke-width="4" stroke-dasharray="inherit" style="fill:red;stroke:black;" />
```

##### Actual
```svg
<rect x="10" y="10" width="180" height="180" stroke-width="4" style="fill:red;stroke:black;" />
```

#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
