### PR TITLE
Fixes position and offset attributes getting written to the text elem…

### DIFF
--- a/Source/Text/SvgTextBase.cs
+++ b/Source/Text/SvgTextBase.cs
@@ -21,10 +21,10 @@ namespace Svg
 
         public SvgTextBase()
         {
-            _x.CollectionChanged += OnCoordinateChanged;
-            _dx.CollectionChanged += OnCoordinateChanged;
-            _y.CollectionChanged += OnCoordinateChanged;
-            _dy.CollectionChanged += OnCoordinateChanged;
+            _x.CollectionChanged += OnXChanged;
+            _dx.CollectionChanged += OnDxChanged;
+            _y.CollectionChanged += OnYChanged;
+            _dy.CollectionChanged += OnDyChanged;
         }
 
         /// <summary>
@@ -64,14 +64,20 @@ namespace Svg
             {
                 if (_x != value)
                 {
-                    if (_x != null) _x.CollectionChanged -= OnCoordinateChanged;
+                    if (_x != null) _x.CollectionChanged -= OnXChanged;
                     _x = value;
-                    if (_x != null) _x.CollectionChanged += OnCoordinateChanged;
+                    if (_x != null) _x.CollectionChanged += OnXChanged;
 
                     IsPathDirty = true;
                 }
                 Attributes["x"] = value;
             }
+        }
+
+        private void OnXChanged(object sender, NotifyCollectionChangedEventArgs e)
+        {
+            Attributes["x"] = X.FirstOrDefault();
+            this.IsPathDirty = true;
         }
 
         /// <summary>
@@ -86,15 +92,22 @@ namespace Svg
             {
                 if (_dx != value)
                 {
-                    if (_dx != null) _dx.CollectionChanged -= OnCoordinateChanged;
+                    if (_dx != null) _dx.CollectionChanged -= OnDxChanged;
                     _dx = value;
-                    if (_dx != null) _dx.CollectionChanged += OnCoordinateChanged;
+                    if (_dx != null) _dx.CollectionChanged += OnDxChanged;
 
                     IsPathDirty = true;
                 }
                 Attributes["dx"] = value;
             }
         }
+
+        private void OnDxChanged(object sender, NotifyCollectionChangedEventArgs e)
+        {
+            Attributes["dx"] = X.FirstOrDefault();
+            this.IsPathDirty = true;
+        }
+
 
         /// <summary>
         /// Gets or sets the Y.
@@ -108,14 +121,20 @@ namespace Svg
             {
                 if (_y != value)
                 {
-                    if (_y != null) _y.CollectionChanged -= OnCoordinateChanged;
+                    if (_y != null) _y.CollectionChanged -= OnYChanged;
                     _y = value;
-                    if (_y != null) _y.CollectionChanged += OnCoordinateChanged;
+                    if (_y != null) _y.CollectionChanged += OnYChanged;
 
                     IsPathDirty = true;
                 }
                 Attributes["y"] = value;
             }
+        }
+
+        private void OnYChanged(object sender, NotifyCollectionChangedEventArgs e)
+        {
+            Attributes["y"] = Y.FirstOrDefault();
+            this.IsPathDirty = true;
         }
 
         /// <summary>
@@ -130,9 +149,9 @@ namespace Svg
             {
                 if (_dy != value)
                 {
-                    if (_dy != null) _dy.CollectionChanged -= OnCoordinateChanged;
+                    if (_dy != null) _dy.CollectionChanged -= OnDyChanged;
                     _dy = value;
-                    if (_dy != null) _dy.CollectionChanged += OnCoordinateChanged;
+                    if (_dy != null) _dy.CollectionChanged += OnDyChanged;
 
                     IsPathDirty = true;
                 }
@@ -140,8 +159,9 @@ namespace Svg
             }
         }
 
-        private void OnCoordinateChanged(object sender, NotifyCollectionChangedEventArgs args)
+        private void OnDyChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
+            Attributes["dy"] = Y.FirstOrDefault();
             this.IsPathDirty = true;
         }
 

--- a/Tests/Svg.UnitTests/SvgTextTests.cs
+++ b/Tests/Svg.UnitTests/SvgTextTests.cs
@@ -43,5 +43,45 @@ namespace Svg.UnitTests
             Assert.AreNotEqual(origX, text.Bounds.X);
             Assert.AreNotEqual(origY, text.Bounds.Y);
         }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [Test]
+        public void TestWritesCoordinatesForCollectionSet()
+        {
+            SvgText text = new SvgText();
+            text.Text = "Test coordinates";
+            text.X = new SvgUnitCollection { 20 };
+            text.Y = new SvgUnitCollection { 30 };
+            text.Dx = new SvgUnitCollection { 40 };
+            text.Dy = new SvgUnitCollection { 50 };
+
+            var xml = text.GetXML();
+            Assert.IsTrue(xml.Contains("x=\"20\""));
+            Assert.IsTrue(xml.Contains("y=\"30\""));
+            Assert.IsTrue(xml.Contains("dx=\"40\""));
+            Assert.IsTrue(xml.Contains("dy=\"50\""));
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [Test]
+        public void TestWritesCoordinatesForCollectionChange()
+        {
+            SvgText text = new SvgText();
+            text.Text = "Test coordinates";
+            text.X.Add(20);
+            text.Y.Add(30);
+            text.Dx.Add(40);
+            text.Dy.Add(50);
+
+            var xml = text.GetXML();
+            Assert.IsTrue(xml.Contains("x=\"20\""));
+            Assert.IsTrue(xml.Contains("y=\"30\""));
+            Assert.IsTrue(xml.Contains("dx=\"40\""));
+            Assert.IsTrue(xml.Contains("dy=\"50\""));
+        }
     }
 }


### PR DESCRIPTION

#### Reference Issue
Fixes #591

#### What does this implement/fix? Explain your changes.
On text elements, the position and offsets are collections. When the collection is changed via an .Add() instead of a set, the attribute does not get set.
This fixes the issue by setting the attribute to the first element in the list.
