### PR TITLE
Remove support for .NET 3.5

### DIFF
--- a/Samples/Entities/Entities.csproj
+++ b/Samples/Entities/Entities.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Entities</RootNamespace>
     <AssemblyName>Entities</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>

--- a/Samples/RuntimeUpdates/SvgSample.csproj
+++ b/Samples/RuntimeUpdates/SvgSample.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SvgSample</RootNamespace>
     <AssemblyName>SvgSample</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>

--- a/Samples/SVGViewer/SVGViewer.csproj
+++ b/Samples/SVGViewer/SVGViewer.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SVGViewer</RootNamespace>
     <AssemblyName>SVGViewer</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>
     </SccProjectName>
@@ -81,15 +81,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Xml.Linq">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Data.DataSetExtensions">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />
     <Reference Include="System.Deployment" />
     <Reference Include="System.Drawing" />
@@ -131,16 +125,6 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
     <BootstrapperPackage Include="Microsoft.Windows.Installer.3.1">
       <Visible>False</Visible>
       <ProductName>Windows Installer 3.1</ProductName>

--- a/Samples/XMLOutput/XMLOutputTester.csproj
+++ b/Samples/XMLOutput/XMLOutputTester.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>XMLOutputTester</RootNamespace>
     <AssemblyName>XMLOutputTester</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">

--- a/Source/Svg.csproj
+++ b/Source/Svg.csproj
@@ -107,7 +107,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Fizzler" Version="1.1.0" />
+    <PackageReference Include="Fizzler" Version="1.2.0" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.167">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Source/Svg.csproj
+++ b/Source/Svg.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp2.2;net35;net452;net472</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp2.2;net452</TargetFrameworks>
     <PackageLicenseExpression>MS-PL</PackageLicenseExpression>
     <RootNamespace>Svg</RootNamespace>
     <AssemblyName>Svg</AssemblyName>
@@ -29,7 +29,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageReleaseNotes>
-      Supports multiple targets v3.5 thru to dotnetcore2.2.
+      Supports multiple targets v4.5.2 thru to dotnetcore2.2.
       NetStandard does not fully support the Drawing2D package - so has been left out.
     </PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/vvvv/SVG</PackageProjectUrl>
@@ -50,27 +50,9 @@
     <DefineConstants>$(DefineConstants);TRACE;RELEASE</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)'=='net35'">
-    <Title>Svg for .Net Framework 3.5</Title>
-    <DefineConstants>$(DefineConstants);NETFULL;NET35</DefineConstants>
-    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)'=='net40'">
-    <Title>Svg for .Net Framework 4.0</Title>
-    <DefineConstants>$(DefineConstants);NETFULL;NET40</DefineConstants>
-    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
-  </PropertyGroup>
-
   <PropertyGroup Condition="'$(TargetFramework)'=='net452'">
     <Title>Svg for .Net Framework 4.5.2</Title>
     <DefineConstants>$(DefineConstants);NETFULL;NET452</DefineConstants>
-    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)'=='net472'">
-    <Title>Svg for .Net Framework 4.7.2</Title>
-    <DefineConstants>$(DefineConstants);NETFULL;NET472</DefineConstants>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
@@ -84,35 +66,7 @@
     <DefineConstants>$(DefineConstants);NETSTANDARD;NETSTANDARD20</DefineConstants>
   </PropertyGroup>
   
-  <ItemGroup Condition="'$(TargetFramework)'=='net35'">
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Web" />
-    <Reference Include="System.Xml" />
-    <Reference Include="WindowsBase" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)'=='net40'">
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Web" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)'=='net452'">
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Web" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)'=='net472'">
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />

--- a/Source/Web/SvgHandler.cs
+++ b/Source/Web/SvgHandler.cs
@@ -1,4 +1,4 @@
-#if NET35 || NET40 || NET452 || NET472
+#if NETFULL
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/Tests/Svg.UnitTests/MultiThreadingTest.cs
+++ b/Tests/Svg.UnitTests/MultiThreadingTest.cs
@@ -1,5 +1,3 @@
-#if NET35
-#else 
 using NUnit.Framework;
 using System.Diagnostics;
 using System.Threading.Tasks;
@@ -34,4 +32,3 @@ namespace Svg.UnitTests
         }
     }
 }
-#endif

--- a/Tests/SvgW3CTestRunner/SvgW3CTestRunner.csproj
+++ b/Tests/SvgW3CTestRunner/SvgW3CTestRunner.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SvgW3CTestRunner</RootNamespace>
     <AssemblyName>SvgW3CTestRunner</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <NoStdLib>False</NoStdLib>

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -3,6 +3,10 @@ The release versions are NuGet releases.
 
 ## Unreleased (master)
 
+### Changes
+* removed support for .NET 3.5
+* upgraded the used Fizzler libary to 1.2.0 (supports Netstandard 1.0 and 2.0)
+
 ## [Version 3.0.84](https://www.nuget.org/packages/Svg/3.0.84)
 
 _**Note:**_


### PR DESCRIPTION
- support will be .NET >= 4.5.2
- removed unneeded 4.7.2 build
- closes #597
