### PR TITLE
Update DeepCopy method of each element.

### DIFF
--- a/Source/Basic Shapes/SvgCircle.cs
+++ b/Source/Basic Shapes/SvgCircle.cs
@@ -92,9 +92,10 @@ namespace Svg
         public override SvgElement DeepCopy<T>()
         {
             var newObj = base.DeepCopy<T>() as SvgCircle;
-            newObj.CenterX = this.CenterX;
-            newObj.CenterY = this.CenterY;
-            newObj.Radius = this.Radius;
+
+            newObj._centerX = _centerX;
+            newObj._centerY = _centerY;
+            newObj._radius = _radius;
             return newObj;
         }
     }

--- a/Source/Basic Shapes/SvgEllipse.cs
+++ b/Source/Basic Shapes/SvgEllipse.cs
@@ -85,7 +85,6 @@ namespace Svg
             }
         }
 
-
         public override SvgElement DeepCopy()
         {
             return DeepCopy<SvgEllipse>();
@@ -94,10 +93,11 @@ namespace Svg
         public override SvgElement DeepCopy<T>()
         {
             var newObj = base.DeepCopy<T>() as SvgEllipse;
-            newObj.CenterX = this.CenterX;
-            newObj.CenterY = this.CenterY;
-            newObj.RadiusX = this.RadiusX;
-            newObj.RadiusY = this.RadiusY;
+
+            newObj._centerX = _centerX;
+            newObj._centerY = _centerY;
+            newObj._radiusX = _radiusX;
+            newObj._radiusY = _radiusY;
             return newObj;
         }
     }

--- a/Source/Basic Shapes/SvgImage.cs
+++ b/Source/Basic Shapes/SvgImage.cs
@@ -354,17 +354,5 @@ namespace Svg
         {
             return DeepCopy<SvgImage>();
         }
-
-        public override SvgElement DeepCopy<T>()
-        {
-            var newObj = base.DeepCopy<T>() as SvgImage;
-            newObj.Height = Height;
-            newObj.Width = Width;
-            newObj.X = X;
-            newObj.Y = Y;
-            newObj.Href = Href;
-            newObj.AspectRatio = new SvgAspectRatio(AspectRatio.Align, AspectRatio.Slice, AspectRatio.Defer);
-            return newObj;
-        }
     }
 }

--- a/Source/Basic Shapes/SvgLine.cs
+++ b/Source/Basic Shapes/SvgLine.cs
@@ -123,13 +123,11 @@ namespace Svg
         public override SvgElement DeepCopy<T>()
         {
             var newObj = base.DeepCopy<T>() as SvgLine;
-            newObj.StartX = this.StartX;
-            newObj.EndX = this.EndX;
-            newObj.StartY = this.StartY;
-            newObj.EndY = this.EndY;
-            if (this.Fill != null)
-                newObj.Fill = this.Fill.DeepCopy() as SvgPaintServer;
 
+            newObj._startX = _startX;
+            newObj._startY = _startY;
+            newObj._endX = _endX;
+            newObj._endY = _endY;
             return newObj;
         }
     }

--- a/Source/Basic Shapes/SvgPolygon.cs
+++ b/Source/Basic Shapes/SvgPolygon.cs
@@ -71,17 +71,5 @@ namespace Svg
         {
             return DeepCopy<SvgPolygon>();
         }
-
-        public override SvgElement DeepCopy<T>()
-        {
-            var newObj = base.DeepCopy<T>() as SvgPolygon;
-            if (Points != null)
-            {
-                newObj.Points = new SvgPointCollection();
-                foreach (var pt in this.Points)
-                    newObj.Points.Add(pt);
-            }
-            return newObj;
-        }
     }
 }

--- a/Source/Basic Shapes/SvgRectangle.cs
+++ b/Source/Basic Shapes/SvgRectangle.cs
@@ -224,7 +224,6 @@ namespace Svg
             }
         }
 
-
         public override SvgElement DeepCopy()
         {
             return DeepCopy<SvgRectangle>();
@@ -233,12 +232,13 @@ namespace Svg
         public override SvgElement DeepCopy<T>()
         {
             var newObj = base.DeepCopy<T>() as SvgRectangle;
-            newObj.CornerRadiusX = this.CornerRadiusX;
-            newObj.CornerRadiusY = this.CornerRadiusY;
-            newObj.Height = this.Height;
-            newObj.Width = this.Width;
-            newObj.X = this.X;
-            newObj.Y = this.Y;
+
+            newObj._x = _x;
+            newObj._y = _y;
+            newObj._width = _width;
+            newObj._height = _height;
+            newObj._cornerRadiusX = _cornerRadiusX;
+            newObj._cornerRadiusY = _cornerRadiusY;
             return newObj;
         }
     }

--- a/Source/Basic Shapes/SvgVisualElement.cs
+++ b/Source/Basic Shapes/SvgVisualElement.cs
@@ -461,31 +461,5 @@ namespace Svg
         {
             this.ResetClip(renderer);
         }
-
-        public override SvgElement DeepCopy<T>()
-        {
-            var newObj = base.DeepCopy<T>() as SvgVisualElement;
-            newObj.ClipPath = this.ClipPath;
-            newObj.ClipRule = this.ClipRule;
-            newObj.Filter = this.Filter;
-
-            newObj.Visible = this.Visible;
-            if (this.Fill != null)
-                newObj.Fill = this.Fill;
-            if (this.Stroke != null)
-                newObj.Stroke = this.Stroke;
-            newObj.FillRule = this.FillRule;
-            newObj.FillOpacity = this.FillOpacity;
-            newObj.StrokeWidth = this.StrokeWidth;
-            newObj.StrokeLineCap = this.StrokeLineCap;
-            newObj.StrokeLineJoin = this.StrokeLineJoin;
-            newObj.StrokeMiterLimit = this.StrokeMiterLimit;
-            newObj.StrokeDashArray = this.StrokeDashArray;
-            newObj.StrokeDashOffset = this.StrokeDashOffset;
-            newObj.StrokeOpacity = this.StrokeOpacity;
-            newObj.Opacity = this.Opacity;
-
-            return newObj;
-        }
     }
 }

--- a/Source/Clipping and Masking/SvgClipPath.cs
+++ b/Source/Clipping and Masking/SvgClipPath.cs
@@ -119,12 +119,5 @@ namespace Svg
         {
             return DeepCopy<SvgClipPath>();
         }
-
-        public override SvgElement DeepCopy<T>()
-        {
-            var newObj = base.DeepCopy<T>() as SvgClipPath;
-            newObj.ClipPathUnits = ClipPathUnits;
-            return newObj;
-        }
     }
 }

--- a/Source/Clipping and Masking/SvgMask.cs
+++ b/Source/Clipping and Masking/SvgMask.cs
@@ -7,6 +7,5 @@ namespace Svg
         {
             return DeepCopy<SvgMask>();
         }
-
     }
 }

--- a/Source/DataTypes/SvgAspectRatio.cs
+++ b/Source/DataTypes/SvgAspectRatio.cs
@@ -1,5 +1,6 @@
-﻿using Svg.DataTypes;
+using System;
 using System.ComponentModel;
+using Svg.DataTypes;
 
 namespace Svg
 {
@@ -7,7 +8,7 @@ namespace Svg
     /// Description of SvgAspectRatio.
     /// </summary>
     [TypeConverter(typeof(SvgPreserveAspectRatioConverter))]
-    public class SvgAspectRatio
+    public class SvgAspectRatio : ICloneable
     {
         public SvgAspectRatio() : this(SvgPreserveAspectRatio.none)
         {
@@ -48,11 +49,15 @@ namespace Svg
             set;
         }
 
+        public object Clone()
+        {
+            return MemberwiseClone();
+        }
+
         public override string ToString()
         {
             return TypeDescriptor.GetConverter(typeof(SvgPreserveAspectRatio)).ConvertToString(this.Align) + (Slice ? " slice" : "");
         }
-
     }
 
     [TypeConverter(typeof(SvgPreserveAspectRatioConverter))]

--- a/Source/DataTypes/SvgPointCollection.cs
+++ b/Source/DataTypes/SvgPointCollection.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
 using System.Text;
@@ -9,8 +10,16 @@ namespace Svg
     /// Represents a list of <see cref="SvgUnit"/> used with the <see cref="SvgPolyline"/> and <see cref="SvgPolygon"/>.
     /// </summary>
     [TypeConverter(typeof(SvgPointCollectionConverter))]
-    public class SvgPointCollection : List<SvgUnit>
+    public class SvgPointCollection : List<SvgUnit>, ICloneable
     {
+        public object Clone()
+        {
+            var points = new SvgPointCollection();
+            foreach (var point in this)
+                points.Add(point);
+            return points;
+        }
+
         public override string ToString()
         {
             var builder = new StringBuilder();

--- a/Source/DataTypes/SvgUnitCollection.cs
+++ b/Source/DataTypes/SvgUnitCollection.cs
@@ -11,7 +11,7 @@ namespace Svg
     /// Represents a list of <see cref="SvgUnit"/>.
     /// </summary>
     [TypeConverter(typeof(SvgUnitCollectionConverter))]
-    public class SvgUnitCollection : ObservableCollection<SvgUnit>
+    public class SvgUnitCollection : ObservableCollection<SvgUnit>, ICloneable
     {
         public static string None = "none";
 
@@ -64,6 +64,16 @@ namespace Svg
         {
             return collection == null || collection.Count < 1 ||
                 (collection.Count == 1 && (collection[0] == SvgUnit.Empty || collection[0] == SvgUnit.None));
+        }
+
+        public object Clone()
+        {
+            var units = new SvgUnitCollection
+            {
+                StringForEmptyValue = StringForEmptyValue
+            };
+            units.AddRange(this);
+            return units;
         }
     }
 

--- a/Source/Document Structure/SvgDescription.cs
+++ b/Source/Document Structure/SvgDescription.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.ComponentModel;
 
 namespace Svg
@@ -17,12 +14,6 @@ namespace Svg
         public override SvgElement DeepCopy()
         {
             return DeepCopy<SvgDescription>();
-        }
-
-        public override SvgElement DeepCopy<T>()
-        {
-            var newObj = base.DeepCopy<T>() as SvgDescription;
-            return newObj;
         }
     }
 }

--- a/Source/Document Structure/SvgFragment.cs
+++ b/Source/Document Structure/SvgFragment.cs
@@ -11,6 +11,9 @@ namespace Svg
     [SvgElement("svg")]
     public class SvgFragment : SvgElement, ISvgViewPort, ISvgBoundable
     {
+        private SvgUnit _x = 0f;
+        private SvgUnit _y = 0f;
+
         /// <summary>
         /// Gets the SVG namespace string.
         /// </summary>
@@ -39,9 +42,6 @@ namespace Svg
                 return new RectangleF(((ISvgBoundable)this).Location, ((ISvgBoundable)this).Size);
             }
         }
-
-        private SvgUnit _x = 0f;
-        private SvgUnit _y = 0f;
 
         /// <summary>
         /// Gets or sets the position where the left point of the svg should start.
@@ -292,11 +292,9 @@ namespace Svg
         public override SvgElement DeepCopy<T>()
         {
             var newObj = base.DeepCopy<T>() as SvgFragment;
-            newObj.Height = this.Height;
-            newObj.Width = this.Width;
-            newObj.Overflow = this.Overflow;
-            newObj.ViewBox = this.ViewBox;
-            newObj.AspectRatio = this.AspectRatio;
+
+            newObj._x = _x;
+            newObj._y = _y;
             return newObj;
         }
 

--- a/Source/Document Structure/SvgGroup.cs
+++ b/Source/Document Structure/SvgGroup.cs
@@ -103,13 +103,5 @@ namespace Svg
         {
             return DeepCopy<SvgGroup>();
         }
-
-        public override SvgElement DeepCopy<T>()
-        {
-            var newObj = base.DeepCopy<T>() as SvgGroup;
-            if (this.Fill != null)
-                newObj.Fill = this.Fill.DeepCopy() as SvgPaintServer;
-            return newObj;
-        }
     }
 }

--- a/Source/Document Structure/SvgSwitch.cs
+++ b/Source/Document Structure/SvgSwitch.cs
@@ -13,7 +13,7 @@ namespace Svg
         /// Gets the <see cref="GraphicsPath"/> for this element.
         /// </summary>
         /// <value></value>
-        public override System.Drawing.Drawing2D.GraphicsPath Path(ISvgRenderer renderer)
+        public override GraphicsPath Path(ISvgRenderer renderer)
         {
             return GetPaths(this, renderer);
         }
@@ -22,7 +22,7 @@ namespace Svg
         /// Gets the bounds of the element.
         /// </summary>
         /// <value>The bounds.</value>
-        public override System.Drawing.RectangleF Bounds
+        public override RectangleF Bounds
         {
             get
             {
@@ -79,14 +79,6 @@ namespace Svg
         public override SvgElement DeepCopy()
         {
             return DeepCopy<SvgSwitch>();
-        }
-
-        public override SvgElement DeepCopy<T>()
-        {
-            var newObj = base.DeepCopy<T>() as SvgSwitch;
-            if (this.Fill != null)
-                newObj.Fill = this.Fill.DeepCopy() as SvgPaintServer;
-            return newObj;
         }
     }
 }

--- a/Source/Document Structure/SvgSymbol.cs
+++ b/Source/Document Structure/SvgSymbol.cs
@@ -101,13 +101,5 @@ namespace Svg.Document_Structure
         {
             return DeepCopy<SvgSymbol>();
         }
-
-        public override SvgElement DeepCopy<T>()
-        {
-            var newObj = base.DeepCopy<T>() as SvgSymbol;
-            if (this.Fill != null)
-                newObj.Fill = this.Fill.DeepCopy() as SvgPaintServer;
-            return newObj;
-        }
     }
 }

--- a/Source/Document Structure/SvgTitle.cs
+++ b/Source/Document Structure/SvgTitle.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
-using System.ComponentModel;
-
 namespace Svg
 {
     [SvgElement("title")]
@@ -17,12 +12,5 @@ namespace Svg
         {
             return DeepCopy<SvgTitle>();
         }
-
-        public override SvgElement DeepCopy<T>()
-        {
-            var newObj = base.DeepCopy<T>() as SvgTitle;
-            return newObj;
-        }
-
     }
 }

--- a/Source/Document Structure/SvgUse.cs
+++ b/Source/Document Structure/SvgUse.cs
@@ -106,7 +106,7 @@ namespace Svg
             return true;
         }
 
-        public override System.Drawing.Drawing2D.GraphicsPath Path(ISvgRenderer renderer)
+        public override GraphicsPath Path(ISvgRenderer renderer)
         {
             SvgVisualElement element = (SvgVisualElement)this.OwnerDocument.IdManager.GetElementById(this.ReferencedElement);
             return (element != null && !this.HasRecursiveReference()) ? element.Path(renderer) : null;
@@ -124,7 +124,7 @@ namespace Svg
         /// Gets the bounds of the element.
         /// </summary>
         /// <value>The bounds.</value>
-        public override System.Drawing.RectangleF Bounds
+        public override RectangleF Bounds
         {
             get
             {
@@ -139,7 +139,7 @@ namespace Svg
                     return element.Bounds;
                 }
 
-                return new System.Drawing.RectangleF();
+                return new RectangleF();
             }
         }
 
@@ -193,16 +193,6 @@ namespace Svg
         public override SvgElement DeepCopy()
         {
             return DeepCopy<SvgUse>();
-        }
-
-        public override SvgElement DeepCopy<T>()
-        {
-            var newObj = base.DeepCopy<T>() as SvgUse;
-            newObj.ReferencedElement = this.ReferencedElement;
-            newObj.X = this.X;
-            newObj.Y = this.Y;
-
-            return newObj;
         }
     }
 }

--- a/Source/Extensibility/SvgForeignObject.cs
+++ b/Source/Extensibility/SvgForeignObject.cs
@@ -13,7 +13,7 @@ namespace Svg
         /// Gets the <see cref="GraphicsPath"/> for this element.
         /// </summary>
         /// <value></value>
-        public override System.Drawing.Drawing2D.GraphicsPath Path(ISvgRenderer renderer)
+        public override GraphicsPath Path(ISvgRenderer renderer)
         {
             return GetPaths(this, renderer);
         }
@@ -22,7 +22,7 @@ namespace Svg
         /// Gets the bounds of the element.
         /// </summary>
         /// <value>The bounds.</value>
-        public override System.Drawing.RectangleF Bounds
+        public override RectangleF Bounds
         {
             get
             {
@@ -73,14 +73,6 @@ namespace Svg
         public override SvgElement DeepCopy()
         {
             return DeepCopy<SvgForeignObject>();
-        }
-
-        public override SvgElement DeepCopy<T>()
-        {
-            var newObj = base.DeepCopy<T>() as SvgForeignObject;
-            if (this.Fill != null)
-                newObj.Fill = this.Fill.DeepCopy() as SvgPaintServer;
-            return newObj;
         }
     }
 }

--- a/Source/Filter Effects/SvgFilter.cs
+++ b/Source/Filter Effects/SvgFilter.cs
@@ -142,16 +142,5 @@ namespace Svg.FilterEffects
         {
             return DeepCopy<SvgFilter>();
         }
-
-        public override SvgElement DeepCopy<T>()
-        {
-            var newObj = base.DeepCopy<T>() as SvgFilter;
-            newObj.Height = this.Height;
-            newObj.Width = this.Width;
-            newObj.X = this.X;
-            newObj.Y = this.Y;
-            newObj.ColorInterpolationFilters = this.ColorInterpolationFilters;
-            return newObj;
-        }
     }
 }

--- a/Source/Filter Effects/feColourMatrix/SvgColourMatrix.cs
+++ b/Source/Filter Effects/feColourMatrix/SvgColourMatrix.cs
@@ -1,9 +1,8 @@
 using System;
 using System.Drawing;
-using System.Collections.Generic;
-using System.Linq;
 using System.Drawing.Imaging;
 using System.Globalization;
+using System.Linq;
 
 namespace Svg.FilterEffects
 {
@@ -123,12 +122,10 @@ namespace Svg.FilterEffects
         public override SvgElement DeepCopy<T>()
         {
             var newObj = base.DeepCopy<T>() as SvgColourMatrix;
-            newObj.Type = this.Type;
-            newObj.Values = this.Values;
 
+            newObj._type = _type;
+            newObj._values = _values;
             return newObj;
         }
-
-
     }
 }

--- a/Source/Filter Effects/feGaussianBlur/SvgGaussianBlur.cs
+++ b/Source/Filter Effects/feGaussianBlur/SvgGaussianBlur.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Drawing;
-using System.Collections.Generic;
 
 namespace Svg.FilterEffects
 {
@@ -15,14 +14,12 @@ namespace Svg.FilterEffects
     public class SvgGaussianBlur : SvgFilterPrimitive
     {
         private float _stdDeviation;
-        private BlurType _blurType;
-
         private int[] _kernel;
         private int _kernelSum;
         private int[,] _multable;
 
         public SvgGaussianBlur()
-            : this(1, BlurType.Both)
+            : this(1f, BlurType.Both)
         {
         }
 
@@ -35,11 +32,9 @@ namespace Svg.FilterEffects
             : base()
         {
             _stdDeviation = stdDeviation;
-            _blurType = blurType;
+            BlurType = blurType;
             PreCalculate();
         }
-
-
 
         private void PreCalculate()
         {
@@ -103,7 +98,7 @@ namespace Svg.FilterEffects
 
                     int start = 0;
                     int index = 0;
-                    if (_blurType != BlurType.VerticalOnly)
+                    if (BlurType != BlurType.VerticalOnly)
                     {
                         for (int i = 0; i < pixelCount; i++)
                         {
@@ -135,7 +130,7 @@ namespace Svg.FilterEffects
                             r2[i] = (rsum / _kernelSum);
                             a2[i] = (asum / _kernelSum);
 
-                            if (_blurType == BlurType.HorizontalOnly)
+                            if (BlurType == BlurType.HorizontalOnly)
                             {
                                 dest.ArgbValues[index] = (byte)(bsum / _kernelSum);
                                 dest.ArgbValues[++index] = (byte)(gsum / _kernelSum);
@@ -151,7 +146,7 @@ namespace Svg.FilterEffects
                         }
                     }
 
-                    if (_blurType == BlurType.HorizontalOnly)
+                    if (BlurType == BlurType.HorizontalOnly)
                     {
                         return dest.Bitmap;
                     }
@@ -169,7 +164,7 @@ namespace Svg.FilterEffects
                             tempy = y;
                             for (int z = 0; z < _kernel.Length; z++)
                             {
-                                if (_blurType == BlurType.VerticalOnly)
+                                if (BlurType == BlurType.VerticalOnly)
                                 {
                                     if (tempy < 0)
                                     {
@@ -232,7 +227,7 @@ namespace Svg.FilterEffects
             get { return _stdDeviation; }
             set
             {
-                if (value <= 0)
+                if (value <= 0f)
                 {
                     throw new InvalidOperationException("Radius must be greater then 0");
                 }
@@ -242,17 +237,7 @@ namespace Svg.FilterEffects
             }
         }
 
-
-        public BlurType BlurType
-        {
-            get { return _blurType; }
-            set
-            {
-                _blurType = value;
-            }
-        }
-
-
+        public BlurType BlurType { get; set; }
 
         public override void Process(ImageBuffer buffer)
         {
@@ -260,8 +245,6 @@ namespace Svg.FilterEffects
             var result = Apply(inputImage);
             buffer[this.Result] = result;
         }
-
-
 
         public override SvgElement DeepCopy()
         {
@@ -271,8 +254,10 @@ namespace Svg.FilterEffects
         public override SvgElement DeepCopy<T>()
         {
             var newObj = base.DeepCopy<T>() as SvgGaussianBlur;
-            newObj.StdDeviation = this.StdDeviation;
-            newObj.BlurType = this.BlurType;
+
+            newObj._stdDeviation = _stdDeviation;
+            newObj.BlurType = BlurType;
+            PreCalculate();
             return newObj;
         }
     }

--- a/Source/Filter Effects/feMerge/SvgMerge.cs
+++ b/Source/Filter Effects/feMerge/SvgMerge.cs
@@ -1,10 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Collections.Specialized;
-using System.Text;
 using System.Drawing;
-using System.Drawing.Drawing2D;
-using System.Drawing.Imaging;
 using System.Linq;
 
 namespace Svg.FilterEffects
@@ -33,6 +27,5 @@ namespace Svg.FilterEffects
         {
             return DeepCopy<SvgMerge>();
         }
-
     }
 }

--- a/Source/Filter Effects/feOffset/SvgOffset.cs
+++ b/Source/Filter Effects/feOffset/SvgOffset.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Drawing;
-using System.Collections.Generic;
 
 namespace Svg.FilterEffects
 {
@@ -59,15 +57,6 @@ namespace Svg.FilterEffects
         public override SvgElement DeepCopy()
         {
             return DeepCopy<SvgOffset>();
-        }
-
-        public override SvgElement DeepCopy<T>()
-        {
-            var newObj = base.DeepCopy<T>() as SvgOffset;
-            newObj.Dx = this.Dx;
-            newObj.Dy = this.Dy;
-
-            return newObj;
         }
     }
 }

--- a/Source/Painting/SvgColourServer.cs
+++ b/Source/Painting/SvgColourServer.cs
@@ -67,7 +67,8 @@ namespace Svg
                 return this;
 
             var newObj = base.DeepCopy<T>() as SvgColourServer;
-            newObj.Colour = this.Colour;
+
+            newObj.Colour = Colour;
             return newObj;
         }
 

--- a/Source/Painting/SvgDeferredPaintServer.cs
+++ b/Source/Painting/SvgDeferredPaintServer.cs
@@ -94,6 +94,7 @@ namespace Svg
         public override SvgElement DeepCopy<T>()
         {
             var newObj = base.DeepCopy<T>() as SvgDeferredPaintServer;
+
             newObj.DeferredId = DeferredId;
             newObj.FallbackServer = FallbackServer?.DeepCopy() as SvgPaintServer;
             return newObj;

--- a/Source/Painting/SvgFallbackPaintServer.cs
+++ b/Source/Painting/SvgFallbackPaintServer.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Drawing;
 
 namespace Svg
@@ -39,11 +38,19 @@ namespace Svg
         {
             return base.DeepCopy<SvgFallbackPaintServer>();
         }
+
         public override SvgElement DeepCopy<T>()
         {
             var newObj = base.DeepCopy<T>() as SvgFallbackPaintServer;
-            newObj._fallbacks = this._fallbacks;
-            newObj._primary = this._primary;
+
+            newObj._primary = _primary?.DeepCopy() as SvgPaintServer;
+            if (_fallbacks != null)
+            {
+                var fallbacks = new List<SvgPaintServer>();
+                foreach (var server in _fallbacks)
+                    fallbacks.Add(server.DeepCopy() as SvgPaintServer);
+                newObj._fallbacks = fallbacks;
+            }
             return newObj;
         }
     }

--- a/Source/Painting/SvgGradientServer.cs
+++ b/Source/Painting/SvgGradientServer.cs
@@ -226,17 +226,5 @@ namespace Svg
         {
             return (float)Math.Sqrt(Math.Pow(vector.X, 2) + Math.Pow(vector.Y, 2));
         }
-
-        public override SvgElement DeepCopy<T>()
-        {
-            var newObj = base.DeepCopy<T>() as SvgGradientServer;
-
-            newObj.SpreadMethod = SpreadMethod;
-            newObj.GradientUnits = GradientUnits;
-            newObj.InheritGradient = InheritGradient;
-            newObj.GradientTransform = GradientTransform;
-
-            return newObj;
-        }
     }
 }

--- a/Source/Painting/SvgGradientStop.cs
+++ b/Source/Painting/SvgGradientStop.cs
@@ -10,7 +10,7 @@ namespace Svg
     [SvgElement("stop")]
     public class SvgGradientStop : SvgElement
     {
-        private SvgUnit _offset = 0f;
+        private SvgUnit _offset;
 
         /// <summary>
         /// Gets or sets the offset, i.e. where the stop begins from the beginning, of the gradient stop.
@@ -21,30 +21,11 @@ namespace Svg
             get { return _offset; }
             set
             {
-                SvgUnit unit = value;
-
-                if (value.Type == SvgUnitType.Percentage)
-                {
-                    if (value.Value > 100f)
-                    {
-                        unit = new SvgUnit(value.Type, 100f);
-                    }
-                    else if (value.Value < 0f)
-                    {
-                        unit = new SvgUnit(value.Type, 0f);
-                    }
-                }
-                else if (value.Type == SvgUnitType.User)
-                {
-                    if (value.Value > 1f)
-                    {
-                        unit = new SvgUnit(value.Type, 1f);
-                    }
-                    else if (value.Value < 0f)
-                    {
-                        unit = new SvgUnit(value.Type, 0f);
-                    }
-                }
+                var unit = value;
+                if (unit.Type == SvgUnitType.Percentage)
+                    unit = new SvgUnit(unit.Type, Math.Min(Math.Max(unit.Value, 0f), 100f));
+                else if (unit.Type == SvgUnitType.User)
+                    unit = new SvgUnit(unit.Type, Math.Min(Math.Max(unit.Value, 0f), 1f));
 
                 _offset = unit.ToPercentage();
                 Attributes["offset"] = unit;
@@ -105,7 +86,8 @@ namespace Svg
         public override SvgElement DeepCopy<T>()
         {
             var newObj = base.DeepCopy<T>() as SvgGradientStop;
-            newObj.Offset = this.Offset;
+
+            newObj._offset = _offset;
             return newObj;
         }
     }

--- a/Source/Painting/SvgLinearGradientServer.cs
+++ b/Source/Painting/SvgLinearGradientServer.cs
@@ -412,17 +412,6 @@ namespace Svg
             return DeepCopy<SvgLinearGradientServer>();
         }
 
-        public override SvgElement DeepCopy<T>()
-        {
-            var newObj = base.DeepCopy<T>() as SvgLinearGradientServer;
-            newObj.X1 = this.X1;
-            newObj.Y1 = this.Y1;
-            newObj.X2 = this.X2;
-            newObj.Y2 = this.Y2;
-            return newObj;
-
-        }
-
         private sealed class LineF
         {
             private float X1

--- a/Source/Painting/SvgMarker.cs
+++ b/Source/Painting/SvgMarker.cs
@@ -127,19 +127,6 @@ namespace Svg
             return DeepCopy<SvgMarker>();
         }
 
-        public override SvgElement DeepCopy<T>()
-        {
-            var newObj = base.DeepCopy<T>() as SvgMarker;
-            newObj.RefX = this.RefX;
-            newObj.RefY = this.RefY;
-            newObj.Orient = this.Orient;
-            newObj.ViewBox = this.ViewBox;
-            newObj.Overflow = this.Overflow;
-            newObj.AspectRatio = this.AspectRatio;
-
-            return newObj;
-        }
-
         /// <summary>
         /// Render this marker using the slope of the given line segment
         /// </summary>

--- a/Source/Painting/SvgPatternServer.cs
+++ b/Source/Painting/SvgPatternServer.cs
@@ -251,13 +251,14 @@ namespace Svg
         public override SvgElement DeepCopy<T>()
         {
             var newObj = base.DeepCopy<T>() as SvgPatternServer;
-            newObj.X = X;
-            newObj.Y = Y;
-            newObj.Width = Width;
-            newObj.Height = Height;
-            newObj.ViewBox = ViewBox;
-            newObj.Overflow = Overflow;
-            newObj.AspectRatio = AspectRatio;
+
+            newObj._x = _x;
+            newObj._y = _y;
+            newObj._width = _width;
+            newObj._height = _height;
+            newObj._patternUnits = _patternUnits;
+            newObj._patternContentUnits = _patternContentUnits;
+            newObj._viewBox = _viewBox;
             return newObj;
         }
     }

--- a/Source/Painting/SvgRadialGradientServer.cs
+++ b/Source/Painting/SvgRadialGradientServer.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics;
 using System.Drawing;
 using System.Collections.Generic;
 using System.Drawing.Drawing2D;
@@ -363,19 +362,6 @@ namespace Svg
         public override SvgElement DeepCopy()
         {
             return DeepCopy<SvgRadialGradientServer>();
-        }
-
-        public override SvgElement DeepCopy<T>()
-        {
-            var newObj = base.DeepCopy<T>() as SvgRadialGradientServer;
-
-            newObj.CenterX = this.CenterX;
-            newObj.CenterY = this.CenterY;
-            newObj.Radius = this.Radius;
-            newObj.FocalX = this.FocalX;
-            newObj.FocalY = this.FocalY;
-
-            return newObj;
         }
     }
 }

--- a/Source/Paths/SvgPath.cs
+++ b/Source/Paths/SvgPath.cs
@@ -105,16 +105,12 @@ namespace Svg
         public override SvgElement DeepCopy<T>()
         {
             var newObj = base.DeepCopy<T>() as SvgPath;
-            if (PathData != null)
+
+            if (newObj.PathData != null)
             {
-                var pathData = new SvgPathSegmentList();
-                foreach (var segment in PathData)
-                    pathData.Add(segment.Clone());
-                newObj.PathData = pathData;
+                newObj.PathData.Owner = newObj;
+                newObj.IsPathDirty = true;
             }
-            newObj.PathLength = PathLength;
-            newObj.MarkerStart = MarkerStart;
-            newObj.MarkerEnd = MarkerEnd;
             return newObj;
         }
     }

--- a/Source/Paths/SvgPathSegmentList.cs
+++ b/Source/Paths/SvgPathSegmentList.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -5,7 +6,7 @@ using System.ComponentModel;
 namespace Svg.Pathing
 {
     [TypeConverter(typeof(SvgPathBuilder))]
-    public sealed class SvgPathSegmentList : IList<SvgPathSegment>
+    public sealed class SvgPathSegmentList : IList<SvgPathSegment>, ICloneable
     {
         private readonly List<SvgPathSegment> _segments = new List<SvgPathSegment>();
 
@@ -96,6 +97,14 @@ namespace Svg.Pathing
         IEnumerator IEnumerable.GetEnumerator()
         {
             return _segments.GetEnumerator();
+        }
+
+        public object Clone()
+        {
+            var segments = new SvgPathSegmentList();
+            foreach (var segment in this)
+                segments.Add(segment.Clone());
+            return segments;
         }
     }
 

--- a/Source/SvgElement.cs
+++ b/Source/SvgElement.cs
@@ -956,7 +956,7 @@ namespace Svg
         /// </returns>
         public virtual object Clone()
         {
-            return this.MemberwiseClone();
+            return DeepCopy();
         }
 
         public abstract SvgElement DeepCopy();
@@ -970,7 +970,6 @@ namespace Svg
         {
             var newObj = new T
             {
-                ID = ID,
                 Content = Content,
                 ElementName = ElementName
             };
@@ -978,8 +977,11 @@ namespace Svg
             //if (this.Parent != null)
             //    this.Parent.Children.Add(newObj);
 
-            if (Transforms != null)
-                newObj.Transforms = Transforms.Clone() as SvgTransformCollection;
+            foreach (var attribute in Attributes)
+            {
+                var value = attribute.Value is ICloneable ? ((ICloneable)attribute.Value).Clone() : attribute.Value;
+                newObj.Attributes.Add(attribute.Key, value);
+            }
 
             foreach (var child in Children)
                 newObj.Children.Add(child.DeepCopy());

--- a/Source/SvgElement.cs
+++ b/Source/SvgElement.cs
@@ -968,29 +968,27 @@ namespace Svg
 
         public virtual SvgElement DeepCopy<T>() where T : SvgElement, new()
         {
-            var newObj = new T();
-            newObj.ID = this.ID;
-            newObj.Content = this.Content;
-            newObj.ElementName = this.ElementName;
+            var newObj = new T
+            {
+                ID = ID,
+                Content = Content,
+                ElementName = ElementName
+            };
 
             //if (this.Parent != null)
             //    this.Parent.Children.Add(newObj);
 
-            if (this.Transforms != null)
-            {
-                newObj.Transforms = this.Transforms.Clone() as SvgTransformCollection;
-            }
+            if (Transforms != null)
+                newObj.Transforms = Transforms.Clone() as SvgTransformCollection;
 
-            foreach (var child in this.Children)
-            {
+            foreach (var child in Children)
                 newObj.Children.Add(child.DeepCopy());
-            }
 
-            foreach (var attr in this._svgEventAttributes)
+            foreach (var attr in _svgEventAttributes)
             {
                 var evt = attr.Event.GetValue(this);
 
-                //if someone has registered also register here
+                // if someone has registered also register here
                 if (evt != null)
                 {
                     if (attr.Event.Name == "MouseDown")
@@ -1007,26 +1005,17 @@ namespace Svg
                         newObj.MouseScroll += delegate { };
                     else if (attr.Event.Name == "Click")
                         newObj.Click += delegate { };
-                    else if (attr.Event.Name == "Change") //text element
+                    else if (attr.Event.Name == "Change") // text element
                         (newObj as SvgText).Change += delegate { };
                 }
             }
 
-            if (this._customAttributes.Count > 0)
-            {
-                foreach (var element in _customAttributes)
-                {
-                    newObj.CustomAttributes.Add(element.Key, element.Value);
-                }
-            }
+            foreach (var attribute in CustomAttributes)
+                newObj.CustomAttributes.Add(attribute.Key, attribute.Value);
 
-            if (this._nodes.Count > 0)
-            {
-                foreach (var node in this._nodes)
-                {
-                    newObj.Nodes.Add(node.DeepCopy());
-                }
-            }
+            foreach (var node in Nodes)
+                newObj.Nodes.Add(node.DeepCopy());
+
             return newObj;
         }
 

--- a/Source/Text/SvgFont.cs
+++ b/Source/Text/SvgFont.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Linq;
 
 namespace Svg
 {
@@ -14,30 +11,35 @@ namespace Svg
             get { return GetAttribute("horiz-adv-x", true, 0f); }
             set { Attributes["horiz-adv-x"] = value; }
         }
+
         [SvgAttribute("horiz-origin-x")]
         public float HorizOriginX
         {
             get { return GetAttribute("horiz-origin-x", true, 0f); }
             set { Attributes["horiz-origin-x"] = value; }
         }
+
         [SvgAttribute("horiz-origin-y")]
         public float HorizOriginY
         {
             get { return GetAttribute("horiz-origin-y", true, 0f); }
             set { Attributes["horiz-origin-y"] = value; }
         }
+
         [SvgAttribute("vert-adv-y")]
         public float VertAdvY
         {
             get { return GetAttribute("vert-adv-y", true, Children.OfType<SvgFontFace>().First().UnitsPerEm); }
             set { Attributes["vert-adv-y"] = value; }
         }
+
         [SvgAttribute("vert-origin-x")]
         public float VertOriginX
         {
             get { return GetAttribute("vert-origin-x", true, HorizAdvX / 2); }
             set { Attributes["vert-origin-x"] = value; }
         }
+
         [SvgAttribute("vert-origin-y")]
         public float VertOriginY
         {
@@ -55,6 +57,7 @@ namespace Svg
         }
 
         protected override void Render(ISvgRenderer renderer)
-        { }
+        {
+        }
     }
 }

--- a/Source/Text/SvgFontFaceSrc.cs
+++ b/Source/Text/SvgFontFaceSrc.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Svg
+﻿namespace Svg
 {
     [SvgElement("font-face-src")]
     public class SvgFontFaceSrc : SvgElement

--- a/Source/Text/SvgFontFaceUri.cs
+++ b/Source/Text/SvgFontFaceUri.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Svg
 {
@@ -18,14 +15,6 @@ namespace Svg
         public override SvgElement DeepCopy()
         {
             return DeepCopy<SvgFontFaceUri>();
-        }
-
-        public override SvgElement DeepCopy<T>()
-        {
-            var newObj = base.DeepCopy<T>() as SvgFontFaceUri;
-            newObj.ReferencedElement = this.ReferencedElement;
-
-            return newObj;
         }
     }
 }

--- a/Source/Text/SvgGlyph.cs
+++ b/Source/Text/SvgGlyph.cs
@@ -98,13 +98,9 @@ namespace Svg
         public override SvgElement DeepCopy<T>()
         {
             var newObj = base.DeepCopy<T>() as SvgGlyph;
-            if (PathData != null)
-            {
-                var pathData = new SvgPathSegmentList();
-                foreach (var segment in PathData)
-                    pathData.Add(segment.Clone());
-                newObj.PathData = pathData;
-            }
+
+            if (newObj.PathData != null)
+                newObj.PathData.Owner = newObj;
             return newObj;
         }
     }

--- a/Source/Text/SvgKern.cs
+++ b/Source/Text/SvgKern.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Svg
+﻿namespace Svg
 {
     public abstract class SvgKern : SvgElement
     {

--- a/Source/Text/SvgText.cs
+++ b/Source/Text/SvgText.cs
@@ -1,12 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Drawing;
-using System.Drawing.Drawing2D;
-using Svg.DataTypes;
-
-namespace Svg
+﻿namespace Svg
 {
     /// <summary>
     /// The <see cref="SvgText"/> element defines a graphics element consisting of text.
@@ -17,36 +9,22 @@ namespace Svg
         /// <summary>
         /// Initializes the <see cref="SvgText"/> class.
         /// </summary>
-        public SvgText() : base() { }
+        public SvgText()
+        {
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SvgText"/> class.
         /// </summary>
         /// <param name="text">The text.</param>
         public SvgText(string text)
-            : this()
         {
-            this.Text = text;
+            Text = text;
         }
 
         public override SvgElement DeepCopy()
         {
             return DeepCopy<SvgText>();
-        }
-
-        public override SvgElement DeepCopy<T>()
-        {
-            var newObj = base.DeepCopy<T>() as SvgText;
-            newObj.TextAnchor = this.TextAnchor;
-            newObj.WordSpacing = this.WordSpacing;
-            newObj.LetterSpacing = this.LetterSpacing;
-            newObj.Font = this.Font;
-            newObj.FontFamily = this.FontFamily;
-            newObj.FontSize = this.FontSize;
-            newObj.FontWeight = this.FontWeight;
-            newObj.X = this.X;
-            newObj.Y = this.Y;
-            return newObj;
         }
     }
 }

--- a/Source/Text/SvgTextBase.cs
+++ b/Source/Text/SvgTextBase.cs
@@ -32,7 +32,7 @@ namespace Svg
         /// </summary>
         public virtual string Text
         {
-            get { return base.Content; }
+            get { return Content; }
             set
             {
                 Nodes.Clear();
@@ -41,15 +41,14 @@ namespace Svg
                 {
                     Nodes.Add(new SvgContentNode { Content = value });
                 }
-                this.IsPathDirty = true;
                 Content = value;
+                IsPathDirty = true;
             }
         }
 
         public override XmlSpaceHandling SpaceHandling
         {
-            get { return base.SpaceHandling; }
-            set { base.SpaceHandling = value; this.IsPathDirty = true; }
+            set { base.SpaceHandling = value; IsPathDirty = true; }
         }
 
         /// <summary>
@@ -508,6 +507,40 @@ namespace Svg
             caller.UnregisterAction(this.ID + "/onchange");
         }
 #endif
+
+        public override SvgElement DeepCopy<T>()
+        {
+            var newObj = base.DeepCopy<T>() as SvgTextBase;
+
+            if (_x != null)
+            {
+                newObj._x = (SvgUnitCollection)_x.Clone();
+                newObj._x.CollectionChanged += newObj.OnXChanged;
+            }
+            if (_y != null)
+            {
+                newObj._y = (SvgUnitCollection)_y.Clone();
+                newObj._y.CollectionChanged += newObj.OnYChanged;
+            }
+            if (_dx != null)
+            {
+                newObj._dx = (SvgUnitCollection)_dx.Clone();
+                newObj._dx.CollectionChanged += newObj.OnDxChanged;
+            }
+            if (_dy != null)
+            {
+                newObj._dy = (SvgUnitCollection)_dy.Clone();
+                newObj._dy.CollectionChanged += newObj.OnDyChanged;
+            }
+            newObj._rotate = _rotate;
+            if (_rotations != null)
+            {
+                newObj._rotations = new List<float>();
+                foreach (var rotation in _rotations)
+                    newObj._rotations.Add(rotation);
+            }
+            return newObj;
+        }
 
         private class FontBoundable : ISvgBoundable
         {

--- a/Source/Text/SvgTextBase.cs
+++ b/Source/Text/SvgTextBase.cs
@@ -512,33 +512,37 @@ namespace Svg
         {
             var newObj = base.DeepCopy<T>() as SvgTextBase;
 
-            if (_x != null)
+            if (_x == null)
+                newObj._x = null;
+            else
             {
                 newObj._x = (SvgUnitCollection)_x.Clone();
                 newObj._x.CollectionChanged += newObj.OnXChanged;
             }
-            if (_y != null)
+            if (_y == null)
+                newObj._y = null;
+            else
             {
                 newObj._y = (SvgUnitCollection)_y.Clone();
                 newObj._y.CollectionChanged += newObj.OnYChanged;
             }
-            if (_dx != null)
+            if (_dx == null)
+                newObj._dx = null;
+            else
             {
                 newObj._dx = (SvgUnitCollection)_dx.Clone();
                 newObj._dx.CollectionChanged += newObj.OnDxChanged;
             }
-            if (_dy != null)
+            if (_dy == null)
+                newObj._dy = null;
+            else
             {
                 newObj._dy = (SvgUnitCollection)_dy.Clone();
                 newObj._dy.CollectionChanged += newObj.OnDyChanged;
             }
             newObj._rotate = _rotate;
-            if (_rotations != null)
-            {
-                newObj._rotations = new List<float>();
-                foreach (var rotation in _rotations)
-                    newObj._rotations.Add(rotation);
-            }
+            foreach (var rotation in _rotations)
+                newObj._rotations.Add(rotation);
             return newObj;
         }
 

--- a/Source/Text/SvgTextPath.cs
+++ b/Source/Text/SvgTextPath.cs
@@ -1,10 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Drawing;
 using System.Drawing.Drawing2D;
-using System.Diagnostics;
 
 namespace Svg
 {

--- a/Source/Text/SvgTextRef.cs
+++ b/Source/Text/SvgTextRef.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace Svg
 {
@@ -38,20 +37,5 @@ namespace Svg
         {
             return DeepCopy<SvgTextRef>();
         }
-
-        public override SvgElement DeepCopy<T>()
-        {
-            var newObj = base.DeepCopy<T>() as SvgTextRef;
-            newObj.X = this.X;
-            newObj.Y = this.Y;
-            newObj.Dx = this.Dx;
-            newObj.Dy = this.Dy;
-            newObj.Text = this.Text;
-            newObj.ReferencedElement = this.ReferencedElement;
-
-            return newObj;
-        }
-
-
     }
 }

--- a/Source/Text/SvgTextSpan.cs
+++ b/Source/Text/SvgTextSpan.cs
@@ -1,11 +1,4 @@
-﻿using System;
-using System.ComponentModel;
-using System.Collections.Generic;
-using System.Drawing.Drawing2D;
-using System.Linq;
-using System.Text;
-
-namespace Svg
+﻿namespace Svg
 {
     [SvgElement("tspan")]
     public class SvgTextSpan : SvgTextBase
@@ -14,19 +7,5 @@ namespace Svg
         {
             return DeepCopy<SvgTextSpan>();
         }
-
-        public override SvgElement DeepCopy<T>()
-        {
-            var newObj = base.DeepCopy<T>() as SvgTextSpan;
-            newObj.X = this.X;
-            newObj.Y = this.Y;
-            newObj.Dx = this.Dx;
-            newObj.Dy = this.Dy;
-            newObj.Text = this.Text;
-
-            return newObj;
-        }
-
-
     }
 }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->

Implementation of `DeepCopy` method of each element class copied attribute via property.
As a result, default value was set at copy destination.

This PR fixes this issue.

#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
