### PR TITLE
Check that there is moveto command at beginning.

### DIFF
--- a/Source/Paths/SvgPath.cs
+++ b/Source/Paths/SvgPath.cs
@@ -49,7 +49,7 @@ namespace Svg
             {
                 _path = new GraphicsPath();
 
-                if (PathData != null)
+                if (PathData != null && PathData.Count > 0 && PathData.First is SvgMoveToSegment)
                 {
                     foreach (var segment in PathData)
                         segment.AddToPath(_path);

--- a/Source/Paths/SvgPathSegmentList.cs
+++ b/Source/Paths/SvgPathSegmentList.cs
@@ -12,6 +12,11 @@ namespace Svg.Pathing
 
         public ISvgPathElement Owner { get; set; }
 
+        public SvgPathSegment First
+        {
+            get { return _segments[0]; }
+        }
+
         public SvgPathSegment Last
         {
             get { return _segments[_segments.Count - 1]; }

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -7,6 +7,9 @@ The release versions are NuGet releases.
 * removed support for .NET 3.5
 * upgraded the used Fizzler libary to 1.2.0 (supports Netstandard 1.0 and 2.0)
 
+### Enhancements
+* check that there is moveto command at beginning (see [PR #616](https://github.com/vvvv/SVG/pull/616))
+
 ## [Version 3.0.84](https://www.nuget.org/packages/Svg/3.0.84)
 
 _**Note:**_


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

Fixes #615 

#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->

In # 615, arcs are drawn...
So, this PR adds check at beginning of command.

A path data segment (if there is one) must begin with a "moveto" command.
https://www.w3.org/TR/SVG11/paths.html#PathDataMovetoCommands

#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
