### PR TITLE
Add new line joins defined by the SVG standard

### DIFF
--- a/Source/Basic Shapes/SvgVisualElement.cs
+++ b/Source/Basic Shapes/SvgVisualElement.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Drawing2D;
@@ -370,6 +370,10 @@ namespace Svg
                                     case SvgStrokeLineJoin.Round:
                                         pen.LineJoin = LineJoin.Round;
                                         break;
+                                    case SvgStrokeLineJoin.MiterClip:
+                                        pen.LineJoin = LineJoin.MiterClipped;
+                                        break;
+                                    // System.Drawing has no support for Arcs unfortunately
                                     default:
                                         pen.LineJoin = LineJoin.Miter;
                                         break;

--- a/Source/Painting/SvgRadialGradientServer.cs
+++ b/Source/Painting/SvgRadialGradientServer.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Drawing;
 using System.Collections.Generic;
 using System.Drawing.Drawing2D;
@@ -56,6 +56,13 @@ namespace Svg
             set { Attributes["fy"] = value; }
         }
 
+        [SvgAttribute("fr")]
+        public SvgUnit FocalRadius
+        {
+            get { return GetAttribute("fr", false, new SvgUnit(SvgUnitType.Percentage, 0f)); }
+            set { Attributes["fr"] = value; }
+        }
+
         private object _lockObj = new Object();
 
         private SvgUnit NormalizeUnit(SvgUnit orig)
@@ -69,6 +76,7 @@ namespace Svg
         {
             LoadStops(renderingElement);
 
+            // TODO: figure out how to do the brush transform in the presence of FocalRadius
             try
             {
                 if (this.GradientUnits == SvgCoordinateUnits.ObjectBoundingBox) renderer.SetBoundable(renderingElement);

--- a/Source/Painting/SvgStrokeLineJoin.cs
+++ b/Source/Painting/SvgStrokeLineJoin.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 using System.ComponentModel;
@@ -15,10 +15,23 @@ namespace Svg
         /// <summary>The corners of the paths are joined sharply.</summary>
         Miter,
 
+        /// <summary>
+        /// The corners of the paths are joined sharply, but clipped at the miter limit instead of
+        /// falling back to SvgStrokeLineJoin.Bevel. This is a new value that might not be supported by
+        /// most browsers.
+        /// </summary>
+        MiterClip,
+
         /// <summary>The corners of the paths are rounded off.</summary>
         Round,
 
         /// <summary>The corners of the paths are "flattened".</summary>
-        Bevel
+        Bevel,
+
+        /// <summary>
+        /// The corners of the paths are joined by arcs that have the same curvature as the curves they
+        /// join. This is a new value that might not be supported by most browsers.
+        /// </summary>
+        Arcs
     }
 }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->
This pull request adds support for two new line joins defined by the SVG standard as stated [here](https://svgwg.org/svg2-draft/painting.html#LineJoin): miter-clip and arcs.

#### Any other comments?
The SVG WG documentation stated that those line joins are at risk because there is no browser implementation for it. I added support for them in [my project of svg renderer](https://github.com/JoaoBaptMG/PathRenderingLab/blob/master/PathRenderingLab/PathCompiler/StrokeUtils.cs#L248), so I would like to have support for them in the SVG loader.