### PR TITLE
Xamarin Forms UWP support for netstandard2.0

### DIFF
--- a/Source/SvgDocument.cs
+++ b/Source/SvgDocument.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;

--- a/Source/SvgDocument.cs
+++ b/Source/SvgDocument.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -206,7 +206,9 @@ namespace Svg
         {
             try
             {
+#if !NETSTANDARD20
                 using (var matrix = new Matrix(0f, 0f, 0f, 0f, 0f, 0f)) { }
+#endif
             }
             // GDI+ loading errors will result in TypeInitializationExceptions, 
             // for readability we will catch and wrap the error

--- a/Source/SvgDocument.cs
+++ b/Source/SvgDocument.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -206,9 +206,7 @@ namespace Svg
         {
             try
             {
-#if !NETSTANDARD20
                 using (var matrix = new Matrix(0f, 0f, 0f, 0f, 0f, 0f)) { }
-#endif
             }
             // GDI+ loading errors will result in TypeInitializationExceptions, 
             // for readability we will catch and wrap the error
@@ -351,7 +349,9 @@ namespace Svg
 
         private static T Open<T>(XmlReader reader) where T : SvgDocument, new()
         {
+#if !NETSTANDARD20
             EnsureSystemIsGdiPlusCapable(); //Validate whether the GDI+ can be loaded, this will yield an exception if not
+#endif
             var elementStack = new Stack<SvgElement>();
             bool elementEmpty;
             SvgElement element = null;

--- a/Source/System/Drawing/ColorConverter.cs
+++ b/Source/System/Drawing/ColorConverter.cs
@@ -51,9 +51,7 @@ namespace System.Drawing {
                     lock(ColorConstantsLock) {
                         if (colorConstants == null) {
                             Hashtable tempHash = new Hashtable(StringComparer.OrdinalIgnoreCase);
-#if !NETSTANDARD20
                             FillConstants(tempHash, typeof(Color));
-#endif
                             colorConstants = tempHash;
                         }
                     }
@@ -74,7 +72,9 @@ namespace System.Drawing {
                     lock (SystemColorConstantsLock) {
                         if (systemColorConstants == null) {
                             Hashtable tempHash = new Hashtable(StringComparer.OrdinalIgnoreCase);
+#if !NETSTANDARD20
                             FillConstants(tempHash, typeof(System.Drawing.SystemColors));
+#endif
                             systemColorConstants = tempHash;
                         }
                     }
@@ -118,9 +118,7 @@ namespace System.Drawing {
             }
             // Ok, how about a system color?
             //
-#if !NETSTANDARD20
             color = SystemColors[name];
-#endif
             return color;
         }
 

--- a/Source/System/Drawing/ColorConverter.cs
+++ b/Source/System/Drawing/ColorConverter.cs
@@ -49,7 +49,9 @@ namespace System.Drawing {
                     lock(ColorConstantsLock) {
                         if (colorConstants == null) {
                             Hashtable tempHash = new Hashtable(StringComparer.OrdinalIgnoreCase);
+#if !NETSTANDARD20
                             FillConstants(tempHash, typeof(Color));
+#endif
                             colorConstants = tempHash;
                         }
                     }
@@ -113,8 +115,9 @@ namespace System.Drawing {
                 return color;
             }
             // Ok, how about a system color?
-            //
+#if !NETSTANDARD20
             color = SystemColors[name];
+#endif
             return color;
         }
 

--- a/Source/System/Drawing/ColorConverter.cs
+++ b/Source/System/Drawing/ColorConverter.cs
@@ -1,4 +1,6 @@
-﻿// https://github.com/dotnet/runtime/blob/master/src/libraries/System.Drawing.Common/src/System/Drawing/ColorConverter.cs
+﻿// This file is based on
+// https://github.com/dotnet/runtime/blob/master/src/libraries/System.Drawing.Common/src/System/Drawing/ColorConverter.cs
+// 6a988c7d0389bf9e9aa20d23baa353e9393b2ea5
 #if NETSTANDARD20
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.

--- a/Source/System/Drawing/ColorConverter.cs
+++ b/Source/System/Drawing/ColorConverter.cs
@@ -117,6 +117,7 @@ namespace System.Drawing {
                 return color;
             }
             // Ok, how about a system color?
+            //
 #if !NETSTANDARD20
             color = SystemColors[name];
 #endif


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->
Fixes exceptions thrown when using `netstandard2.0` and `Xamarin Forms` `UWP` + `Svg.Skia` rendering.

![ApplicationFrameHost_2020-01-08_18-22-30](https://user-images.githubusercontent.com/2297442/72000893-92c88080-3244-11ea-9a71-72449c81a609.png)

#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
Added suggested comment from review:
https://github.com/vvvv/SVG/pull/630#discussion_r363126766