### PR TITLE
Set shape-rendering property default value to auto

### DIFF
--- a/Source/Rendering/SvgRendering.cs
+++ b/Source/Rendering/SvgRendering.cs
@@ -11,7 +11,7 @@ namespace Svg
     /// </summary>
     /// <references>https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/shape-rendering</references>
     /// <remarks>
-    /// Default is <see cref="Inherit"/>. That means the value comes from the parent element. If parents are also not set, then the value is <see cref="Auto"/>.
+    /// Default is <see cref="Auto"/>.
     /// </remarks>
     [TypeConverter(typeof(SvgShapeRenderingConverter))]
     public enum SvgShapeRendering

--- a/Source/SvgElementStyle.cs
+++ b/Source/SvgElementStyle.cs
@@ -154,7 +154,7 @@ namespace Svg
         [SvgAttribute("shape-rendering")]
         public virtual SvgShapeRendering ShapeRendering
         {
-            get { return GetAttribute<SvgShapeRendering>("shape-rendering", true); }
+            get { return GetAttribute<SvgShapeRendering>("shape-rendering", true, SvgShapeRendering.Auto); }
             set { Attributes["shape-rendering"] = value; }
         }
 

--- a/Source/SvgElementStyle.cs
+++ b/Source/SvgElementStyle.cs
@@ -154,7 +154,7 @@ namespace Svg
         [SvgAttribute("shape-rendering")]
         public virtual SvgShapeRendering ShapeRendering
         {
-            get { return GetAttribute<SvgShapeRendering>("shape-rendering", true, SvgShapeRendering.Auto); }
+            get { return GetAttribute("shape-rendering", true, SvgShapeRendering.Auto); }
             set { Attributes["shape-rendering"] = value; }
         }
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->
Sets `shape-rendering` property default value to `auto`.

According to spec default/initial value is `auto`:
https://www.w3.org/TR/SVG11/painting.html#ShapeRenderingProperty
```
Value:  	auto | optimizeSpeed | crispEdges |
geometricPrecision | inherit
Initial:  	auto
Applies to:  	shapes
Inherited:  	yes
Percentages:  	N/A
Media:  	visual
Animatable:  	yes
```
https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/shape-rendering
```
Value	auto | optimizeSpeed | crispEdges | geometricPrecision
Default value	auto
Animatable	Yes
```
#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
