### PR TITLE
Add properties to SvgMask and SvgElement

### DIFF
--- a/Source/Clipping and Masking/SvgMask.cs
+++ b/Source/Clipping and Masking/SvgMask.cs
@@ -1,8 +1,71 @@
 namespace Svg
 {
+    /// <summary>
+    /// Defines an alpha mask for compositing the current object into the background.
+    /// </summary>
     [SvgElement("mask")]
     public class SvgMask : SvgElement
     {
+        /// <summary>
+        /// Defines the coordinate system for attributes <see cref="X"/>, <see cref="Y"/>, <see cref="Width"/> and <see cref="Height"/>.
+        /// </summary>
+        [SvgAttribute("maskUnits")]
+        public SvgCoordinateUnits MaskUnits
+        {
+            get { return GetAttribute("maskUnits", false, SvgCoordinateUnits.ObjectBoundingBox); }
+            set { Attributes["maskUnits"] = value; }
+        }
+
+        /// <summary>
+        /// Defines the coordinate system for the contents of the mask.
+        /// </summary>
+        [SvgAttribute("maskContentUnits")]
+        public SvgCoordinateUnits MaskContentUnits
+        {
+            get { return GetAttribute("maskContentUnits", false, SvgCoordinateUnits.UserSpaceOnUse); }
+            set { Attributes["maskContentUnits"] = value; }
+        }
+
+        /// <summary>
+        /// The x-axis coordinate of one corner of the rectangle for the largest possible offscreen buffer.
+        /// </summary>
+        [SvgAttribute("x")]
+        public SvgUnit X
+        {
+            get { return GetAttribute("x", false, new SvgUnit(SvgUnitType.Percentage, -10f)); }
+            set { Attributes["x"] = value; }
+        }
+
+        /// <summary>
+        /// The y-axis coordinate of one corner of the rectangle for the largest possible offscreen buffer.
+        /// </summary>
+        [SvgAttribute("y")]
+        public SvgUnit Y
+        {
+            get { return GetAttribute("y", false, new SvgUnit(SvgUnitType.Percentage, -10f)); }
+            set { Attributes["y"] = value; }
+        }
+
+        /// <summary>
+        /// The width of the largest possible offscreen buffer.
+        /// </summary>
+        [SvgAttribute("width")]
+        public SvgUnit Width
+        {
+            get { return GetAttribute("width", false, new SvgUnit(SvgUnitType.Percentage, 120f)); }
+            set { Attributes["width"] = value; }
+        }
+
+        /// <summary>
+        /// The height of the largest possible offscreen buffer.
+        /// </summary>
+        [SvgAttribute("height")]
+        public SvgUnit Height
+        {
+            get { return GetAttribute("height", false, new SvgUnit(SvgUnitType.Percentage, 120f)); }
+            set { Attributes["height"] = value; }
+        }
+
         public override SvgElement DeepCopy()
         {
             return DeepCopy<SvgMask>();

--- a/Source/DataTypes/SvgFontStretch.cs
+++ b/Source/DataTypes/SvgFontStretch.cs
@@ -1,0 +1,22 @@
+﻿using System.ComponentModel;
+
+namespace Svg
+{
+    /// <summary>The desired amount of condensing or expansion in the glyphs used to render the text.</summary>
+    [TypeConverter(typeof(SvgFontStretchConverter))]
+    public enum SvgFontStretch
+    {
+        Normal,
+        Wider,
+        Narrower,
+        UltraCondensed,
+        ExtraCondensed,
+        Condensed,
+        SemiCondensed,
+        SemiExpanded,
+        Expanded,
+        ExtraExpanded,
+        UltraExpanded,
+        Inherit
+    }
+}

--- a/Source/Painting/EnumConverters.cs
+++ b/Source/Painting/EnumConverters.cs
@@ -269,6 +269,45 @@ namespace Svg
         }
     }
 
+    public sealed class SvgFontStretchConverter : EnumBaseConverter<SvgFontStretch>
+    {
+        public SvgFontStretchConverter() : base(SvgFontStretch.Normal) { }
+
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            if (value is string)
+            {
+                switch ((string)value)
+                {
+                    case "ultra-condensed": return SvgFontStretch.UltraCondensed;
+                    case "extra-condensed": return SvgFontStretch.ExtraCondensed;
+                    case "semi-condensed": return SvgFontStretch.SemiCondensed;
+                    case "semi-expanded ": return SvgFontStretch.SemiExpanded;
+                    case "extra-expanded": return SvgFontStretch.ExtraExpanded;
+                    case "ultra-expanded": return SvgFontStretch.UltraExpanded;
+                }
+            }
+            return base.ConvertFrom(context, culture, value);
+        }
+
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        {
+            if (destinationType == typeof(string) && value is SvgFontStretch)
+            {
+                switch ((SvgFontStretch)value)
+                {
+                    case SvgFontStretch.UltraCondensed: return "ultra-condensed";
+                    case SvgFontStretch.ExtraCondensed: return "extra-condensed";
+                    case SvgFontStretch.SemiCondensed: return "semi-condensed";
+                    case SvgFontStretch.SemiExpanded: return "semi-expanded";
+                    case SvgFontStretch.ExtraExpanded: return "extra-expanded";
+                    case SvgFontStretch.UltraExpanded: return "ultra-expanded";
+                }
+            }
+            return base.ConvertTo(context, culture, value, destinationType);
+        }
+    }
+
     public sealed class SvgFontWeightConverter : EnumBaseConverter<SvgFontWeight>
     {
         //TODO Defaulting to Normal although it should be All if this is used on a font face.

--- a/Source/SvgElementStyle.cs
+++ b/Source/SvgElementStyle.cs
@@ -239,6 +239,16 @@ namespace Svg
         }
 
         /// <summary>
+        /// Indicates the desired amount of condensing or expansion in the glyphs used to render the text.
+        /// </summary>
+        [SvgAttribute("font-stretch")]
+        public virtual SvgFontStretch FontStretch
+        {
+            get { return GetAttribute("font-stretch", true, SvgFontStretch.Inherit); }
+            set { Attributes["font-stretch"] = value; IsPathDirty = true; }
+        }
+
+        /// <summary>
         /// Refers to the text transformation.
         /// </summary>
         [SvgAttribute("text-transform")]

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -9,6 +9,7 @@ The release versions are NuGet releases.
 * added X, Y, Width and Height properties to SvgFilterPrimitive class (see [PR #641](https://github.com/vvvv/SVG/pull/641))
 * added SvgNumberCollection data type similar to SvgPointCollection (see [PR #641](https://github.com/vvvv/SVG/pull/641))
 * added MaskUnits, MaskContentUnits, X, Y, Width and Height properties to SvgMask (see [PR #654](https://github.com/vvvv/SVG/pull/654))
+* added FontStretch property to SvgElement (see [PR #654](https://github.com/vvvv/SVG/pull/654))
 
 ### Fixes
 * fixed CoordinateParser handling of invalid state (see [PR #640](https://github.com/vvvv/SVG/pull/640))

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -8,6 +8,7 @@ The release versions are NuGet releases.
 * added FilterUnits and PrimitiveUnits properties to SvgFilter class (see [PR #641](https://github.com/vvvv/SVG/pull/641))
 * added X, Y, Width and Height properties to SvgFilterPrimitive class (see [PR #641](https://github.com/vvvv/SVG/pull/641))
 * added SvgNumberCollection data type similar to SvgPointCollection (see [PR #641](https://github.com/vvvv/SVG/pull/641))
+* added MaskUnits, MaskContentUnits, X, Y, Width and Height properties to SvgMask (see [PR #654](https://github.com/vvvv/SVG/pull/654))
 
 ### Fixes
 * fixed CoordinateParser handling of invalid state (see [PR #640](https://github.com/vvvv/SVG/pull/640))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #610

#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->
* added MaskUnits, MaskContentUnits, X, Y, Width and Height properties to SvgMask
https://www.w3.org/TR/SVG11/masking.html#MaskElement

* added FontStretch property to SvgElement
https://www.w3.org/TR/SVG11/text.html#FontStretchProperty

#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
