### PR TITLE
Fixed initial values of attributes related to text.

### DIFF
--- a/Source/SvgElementStyle.cs
+++ b/Source/SvgElementStyle.cs
@@ -164,7 +164,7 @@ namespace Svg
         [SvgAttribute("text-anchor")]
         public virtual SvgTextAnchor TextAnchor
         {
-            get { return GetAttribute<SvgTextAnchor>("text-anchor", true); }
+            get { return GetAttribute("text-anchor", true, SvgTextAnchor.Start); }
             set { Attributes["text-anchor"] = value; IsPathDirty = true; }
         }
 
@@ -214,7 +214,7 @@ namespace Svg
         [SvgAttribute("font-variant")]
         public virtual SvgFontVariant FontVariant
         {
-            get { return GetAttribute("font-variant", true, SvgFontVariant.Inherit); }
+            get { return GetAttribute("font-variant", true, SvgFontVariant.Normal); }
             set { Attributes["font-variant"] = value; IsPathDirty = true; }
         }
 
@@ -224,7 +224,7 @@ namespace Svg
         [SvgAttribute("text-decoration")]
         public virtual SvgTextDecoration TextDecoration
         {
-            get { return GetAttribute("text-decoration", true, SvgTextDecoration.Inherit); }
+            get { return GetAttribute("text-decoration", true, SvgTextDecoration.None); }
             set { Attributes["text-decoration"] = value; IsPathDirty = true; }
         }
 
@@ -234,7 +234,7 @@ namespace Svg
         [SvgAttribute("font-weight")]
         public virtual SvgFontWeight FontWeight
         {
-            get { return GetAttribute("font-weight", true, SvgFontWeight.Inherit); }
+            get { return GetAttribute("font-weight", true, SvgFontWeight.Normal); }
             set { Attributes["font-weight"] = value; IsPathDirty = true; }
         }
 
@@ -244,7 +244,7 @@ namespace Svg
         [SvgAttribute("font-stretch")]
         public virtual SvgFontStretch FontStretch
         {
-            get { return GetAttribute("font-stretch", true, SvgFontStretch.Inherit); }
+            get { return GetAttribute("font-stretch", true, SvgFontStretch.Normal); }
             set { Attributes["font-stretch"] = value; IsPathDirty = true; }
         }
 

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -17,6 +17,7 @@ The release versions are NuGet releases.
 * set correct default values for SvgFilter properties (see [PR #641](https://github.com/vvvv/SVG/pull/641))
 * dispose Matrix in SvgFilter (see [PR #644](https://github.com/vvvv/SVG/pull/644))
 * dispose resources in ImageBuffer (see [PR #646](https://github.com/vvvv/SVG/pull/646))
+* fixed initial values of attributes related to text (see [PR #655](https://github.com/vvvv/SVG/pull/655))
 
 ## [Version 3.0.102](https://www.nuget.org/packages/Svg/3.0.102)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

Fixes #610.

#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->

The following initial values have been corrected.

- text-anchor
- font-variant
- text-decoration
- font-weight
- font-stretch

#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
