### PR TITLE
Fixed 'clip-rule' attribute.

### DIFF
--- a/Source/Basic Shapes/SvgVisualElement.cs
+++ b/Source/Basic Shapes/SvgVisualElement.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Drawing2D;
@@ -69,7 +69,7 @@ namespace Svg
         [SvgAttribute("clip-rule")]
         public SvgClipRule ClipRule
         {
-            get { return GetAttribute("clip-rule", false, SvgClipRule.NonZero); }
+            get { return GetAttribute("clip-rule", true, SvgClipRule.NonZero); }
             set { Attributes["clip-rule"] = value; }
         }
 

--- a/Source/Clipping and Masking/SvgClipRule.cs
+++ b/Source/Clipping and Masking/SvgClipRule.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel;
+﻿using System.ComponentModel;
 
 namespace Svg
 {
@@ -20,6 +20,11 @@ namespace Svg
         /// <summary>
         /// This rule determines the "insideness" of a point on the canvas by drawing a ray from that point to infinity in any direction and counting the number of path segments from the given shape that the ray crosses. If this number is odd, the point is inside; if even, the point is outside.
         /// </summary>
-        EvenOdd
+        EvenOdd,
+
+        /// <summary>
+        /// The value is inherited from the parent element.
+        /// </summary>
+        Inherit,
     }
 }

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -22,6 +22,7 @@ The release versions are NuGet releases.
 * fixed initial values of attributes related to text (see [PR #655](https://github.com/vvvv/SVG/pull/655))
 * fixed 'inherit' does not work at visibility and display (see [PR #656](https://github.com/vvvv/SVG/pull/656))
 * fixed Won't display gradients if they're wider than 698 px (see [#252](https://github.com/vvvv/SVG/issues/252) and [PR #658](https://github.com/vvvv/SVG/pull/658))
+* fixed 'clip-rule' attribute. (see [PR #662](https://github.com/vvvv/SVG/pull/662))
 
 ## [Version 3.0.102](https://www.nuget.org/packages/Svg/3.0.102)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->

https://www.w3.org/TR/SVG11/masking.html#ClipRuleProperty

- Add `Inherit`.
- Set `Inherited` correctly.

#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
