### PR TITLE
Fix color interpolation properties

### DIFF
--- a/Source/Filter Effects/SvgFilter.cs
+++ b/Source/Filter Effects/SvgFilter.cs
@@ -67,17 +67,6 @@ namespace Svg.FilterEffects
         }
 
         /// <summary>
-        /// Gets or sets the color-interpolation-filters of the resulting filter graphic.
-        /// NOT currently mapped through to bitmap
-        /// </summary>
-        [SvgAttribute("color-interpolation-filters")]
-        public SvgColourInterpolation ColorInterpolationFilters
-        {
-            get { return GetAttribute<SvgColourInterpolation>("color-interpolation-filters", false); }
-            set { Attributes["color-interpolation-filters"] = value; }
-        }
-
-        /// <summary>
         /// Renders the <see cref="SvgElement"/> and contents to the specified <see cref="ISvgRenderer"/> object.
         /// </summary>
         /// <param name="renderer">The <see cref="ISvgRenderer"/> object to render to.</param>

--- a/Source/SvgElementStyle.cs
+++ b/Source/SvgElementStyle.cs
@@ -159,6 +159,17 @@ namespace Svg
         }
 
         /// <summary>
+        /// Gets or sets the color space for imaging operations performed via filter effects.
+        /// NOT currently mapped through to bitmap
+        /// </summary>
+        [SvgAttribute("color-interpolation-filters")]
+        public SvgColourInterpolation ColorInterpolationFilters
+        {
+            get { return GetAttribute("color-interpolation-filters", true, SvgColourInterpolation.LinearRGB); }
+            set { Attributes["color-interpolation-filters"] = value; }
+        }
+
+        /// <summary>
         /// Gets or sets a value to determine whether the element will be rendered.
         /// </summary>
         [SvgAttribute("visibility")]

--- a/Source/SvgElementStyle.cs
+++ b/Source/SvgElementStyle.cs
@@ -159,6 +159,16 @@ namespace Svg
         }
 
         /// <summary>
+        /// Gets or sets the color space for gradient interpolations, color animations and alpha compositing.
+        /// </summary>
+        [SvgAttribute("color-interpolation")]
+        public SvgColourInterpolation ColorInterpolation
+        {
+            get { return GetAttribute("color-interpolation", true, SvgColourInterpolation.SRGB); }
+            set { Attributes["color-interpolation"] = value; }
+        }
+
+        /// <summary>
         /// Gets or sets the color space for imaging operations performed via filter effects.
         /// NOT currently mapped through to bitmap
         /// </summary>

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -10,6 +10,8 @@ The release versions are NuGet releases.
 * added SvgNumberCollection data type similar to SvgPointCollection (see [PR #641](https://github.com/vvvv/SVG/pull/641))
 * added MaskUnits, MaskContentUnits, X, Y, Width and Height properties to SvgMask (see [PR #654](https://github.com/vvvv/SVG/pull/654))
 * added FontStretch property to SvgElement (see [PR #654](https://github.com/vvvv/SVG/pull/654))
+* moved ColorInterpolationFilters property to SvgElement because its a presentation attribute (see [PR #667](https://github.com/vvvv/SVG/pull/667))
+* added ColorInterpolation property to SvgElement (see [PR #667](https://github.com/vvvv/SVG/pull/667))
 
 ### Fixes
 * fixed CoordinateParser handling of invalid state (see [PR #640](https://github.com/vvvv/SVG/pull/640))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->

* Moved ColorInterpolationFilters property to SvgElement because its a presentation attribute
  https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/color-interpolation-filters
* Added ColorInterpolation property to SvgElement
  https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/color-interpolation

#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
