### PR TITLE
Remove DefaultValue in EnumConverters.

### DIFF
--- a/Source/DataTypes/EnumConverters.cs
+++ b/Source/DataTypes/EnumConverters.cs
@@ -32,29 +32,16 @@ namespace Svg
         /// <summary>Defines if the enum literal shall be converted to camelCase, lowercase or kebab-case.</summary>
         public CaseHandling CaseHandlingMode { get; }
 
-        /// <summary>If specified, upon conversion, the default value will result in 'null'.</summary>
-        public T? DefaultValue { get; protected set; }
-
         /// <summary>Creates a new instance.</summary>
-        /// <param name="defaultValue">Specified the default value of the enum.</param>
         /// <param name="caseHandling">Defines if the value shall be converted to camelCase, lowercase or kebab-case.</param>
-        public EnumBaseConverter(T defaultValue, CaseHandling caseHandling = CaseHandling.CamelCase)
+        public EnumBaseConverter(CaseHandling caseHandling = CaseHandling.CamelCase)
         {
-            DefaultValue = defaultValue;
             CaseHandlingMode = caseHandling;
         }
 
         /// <summary>Attempts to convert the provided value to <typeparamref name="T"/>.</summary>
         public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
         {
-            if (value == null)
-            {
-                if (DefaultValue.HasValue)
-                    return DefaultValue.Value;
-
-                return Activator.CreateInstance(typeof(T));
-            }
-
             if (value is string stringValue)
             {
                 if (CaseHandlingMode == CaseHandling.KebabCase)
@@ -72,10 +59,6 @@ namespace Svg
         {
             if (destinationType == typeof(string) && value is T)
             {
-                // If the value id the default value, no need to write the attribute.
-                if (DefaultValue.HasValue && Equals(value, DefaultValue.Value))
-                    return null;
-
                 var stringValue = ((T)value).ToString();
                 if (CaseHandlingMode == CaseHandling.CamelCase)
                     return string.Format("{0}{1}", stringValue[0].ToString().ToLower(), stringValue.Substring(1));
@@ -92,110 +75,61 @@ namespace Svg
 
     public sealed class SvgFillRuleConverter : EnumBaseConverter<SvgFillRule>
     {
-        public SvgFillRuleConverter() : base(SvgFillRule.NonZero, CaseHandling.LowerCase) { }
+        public SvgFillRuleConverter() : base(CaseHandling.LowerCase) { }
     }
 
-    public sealed class SvgColourInterpolationConverter : EnumBaseConverter<SvgColourInterpolation>
-    {
-        public SvgColourInterpolationConverter() : base(SvgColourInterpolation.SRGB) { }
-    }
+    public sealed class SvgColourInterpolationConverter : EnumBaseConverter<SvgColourInterpolation> { }
 
     public sealed class SvgClipRuleConverter : EnumBaseConverter<SvgClipRule>
     {
-        public SvgClipRuleConverter() : base(SvgClipRule.NonZero, CaseHandling.LowerCase) { }
+        public SvgClipRuleConverter() : base(CaseHandling.LowerCase) { }
     }
 
-    public sealed class SvgTextAnchorConverter : EnumBaseConverter<SvgTextAnchor>
-    {
-        public SvgTextAnchorConverter() : base(SvgTextAnchor.Start) { }
-    }
+    public sealed class SvgTextAnchorConverter : EnumBaseConverter<SvgTextAnchor> { }
 
-    public sealed class SvgStrokeLineCapConverter : EnumBaseConverter<SvgStrokeLineCap>
-    {
-        public SvgStrokeLineCapConverter() : base(SvgStrokeLineCap.Butt) { }
-    }
+    public sealed class SvgStrokeLineCapConverter : EnumBaseConverter<SvgStrokeLineCap> { }
 
-    public sealed class SvgStrokeLineJoinConverter : EnumBaseConverter<SvgStrokeLineJoin>
-    {
-        public SvgStrokeLineJoinConverter() : base(SvgStrokeLineJoin.Miter) { }
-    }
+    public sealed class SvgStrokeLineJoinConverter : EnumBaseConverter<SvgStrokeLineJoin> { }
 
-    public sealed class SvgMarkerUnitsConverter : EnumBaseConverter<SvgMarkerUnits>
-    {
-        public SvgMarkerUnitsConverter() : base(SvgMarkerUnits.StrokeWidth) { }
-    }
+    public sealed class SvgMarkerUnitsConverter : EnumBaseConverter<SvgMarkerUnits> { }
 
-    public sealed class SvgFontStyleConverter : EnumBaseConverter<SvgFontStyle>
-    {
-        public SvgFontStyleConverter() : base(SvgFontStyle.Normal) { }
-    }
+    public sealed class SvgFontStyleConverter : EnumBaseConverter<SvgFontStyle> { }
 
-    public sealed class SvgOverflowConverter : EnumBaseConverter<SvgOverflow>
-    {
-        public SvgOverflowConverter() : base(SvgOverflow.Auto) { }
-    }
+    public sealed class SvgOverflowConverter : EnumBaseConverter<SvgOverflow> { }
 
-    public sealed class SvgTextLengthAdjustConverter : EnumBaseConverter<SvgTextLengthAdjust>
-    {
-        public SvgTextLengthAdjustConverter() : base(SvgTextLengthAdjust.Spacing) { }
-    }
+    public sealed class SvgTextLengthAdjustConverter : EnumBaseConverter<SvgTextLengthAdjust> { }
 
-    public sealed class SvgTextPathMethodConverter : EnumBaseConverter<SvgTextPathMethod>
-    {
-        public SvgTextPathMethodConverter() : base(SvgTextPathMethod.Align) { }
-    }
+    public sealed class SvgTextPathMethodConverter : EnumBaseConverter<SvgTextPathMethod> { }
 
-    public sealed class SvgTextPathSpacingConverter : EnumBaseConverter<SvgTextPathSpacing>
-    {
-        public SvgTextPathSpacingConverter() : base(SvgTextPathSpacing.Exact) { }
-    }
+    public sealed class SvgTextPathSpacingConverter : EnumBaseConverter<SvgTextPathSpacing> { }
 
-    public sealed class SvgShapeRenderingConverter : EnumBaseConverter<SvgShapeRendering>
-    {
-        public SvgShapeRenderingConverter() : base(SvgShapeRendering.Inherit) { }
-    }
+    public sealed class SvgShapeRenderingConverter : EnumBaseConverter<SvgShapeRendering> { }
 
-    public sealed class SvgTextRenderingConverter : EnumBaseConverter<SvgTextRendering>
-    {
-        public SvgTextRenderingConverter() : base(SvgTextRendering.Inherit) { }
-    }
+    public sealed class SvgTextRenderingConverter : EnumBaseConverter<SvgTextRendering> { }
 
-    public sealed class SvgImageRenderingConverter : EnumBaseConverter<SvgImageRendering>
-    {
-        public SvgImageRenderingConverter() : base(SvgImageRendering.Inherit) { }
-    }
+    public sealed class SvgImageRenderingConverter : EnumBaseConverter<SvgImageRendering> { }
 
     public sealed class SvgFontVariantConverter : EnumBaseConverter<SvgFontVariant>
     {
-        public SvgFontVariantConverter() : base(SvgFontVariant.Normal, CaseHandling.KebabCase) { }
+        public SvgFontVariantConverter() : base(CaseHandling.KebabCase) { }
     }
 
-    public sealed class SvgCoordinateUnitsConverter : EnumBaseConverter<SvgCoordinateUnits>
-    {
-        // TODO Inherit is not actually valid. See TODO on SvgCoordinateUnits enum.
-        public SvgCoordinateUnitsConverter() : base(SvgCoordinateUnits.Inherit) { }
-    }
+    public sealed class SvgCoordinateUnitsConverter : EnumBaseConverter<SvgCoordinateUnits> { }
 
-    public sealed class SvgGradientSpreadMethodConverter : EnumBaseConverter<SvgGradientSpreadMethod>
-    {
-        public SvgGradientSpreadMethodConverter() : base(SvgGradientSpreadMethod.Pad) { }
-    }
+    public sealed class SvgGradientSpreadMethodConverter : EnumBaseConverter<SvgGradientSpreadMethod> { }
 
     public sealed class SvgTextDecorationConverter : EnumBaseConverter<SvgTextDecoration>
     {
-        public SvgTextDecorationConverter() : base(SvgTextDecoration.None, CaseHandling.KebabCase) { }
+        public SvgTextDecorationConverter() : base(CaseHandling.KebabCase) { }
     }
 
     public sealed class SvgFontStretchConverter : EnumBaseConverter<SvgFontStretch>
     {
-        public SvgFontStretchConverter() : base(SvgFontStretch.Normal, CaseHandling.KebabCase) { }
+        public SvgFontStretchConverter() : base(CaseHandling.KebabCase) { }
     }
 
     public sealed class SvgFontWeightConverter : EnumBaseConverter<SvgFontWeight>
     {
-        // TODO Defaulting to Normal although it should be All if this is used on a font face.
-        public SvgFontWeightConverter() : base(SvgFontWeight.Normal) { }
-
         public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
         {
             if (value is string)
@@ -215,6 +149,7 @@ namespace Svg
             }
             return base.ConvertFrom(context, culture, value);
         }
+
         public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
         {
             if (destinationType == typeof(string) && value is SvgFontWeight)
@@ -236,10 +171,7 @@ namespace Svg
         }
     }
 
-    public sealed class SvgTextTransformationConverter : EnumBaseConverter<SvgTextTransformation>
-    {
-        public SvgTextTransformationConverter() : base(SvgTextTransformation.None) { }
-    }
+    public sealed class SvgTextTransformationConverter : EnumBaseConverter<SvgTextTransformation> { }
 
     public static class Enums
     {

--- a/Source/DataTypes/SvgCoordinateUnits.cs
+++ b/Source/DataTypes/SvgCoordinateUnits.cs
@@ -1,21 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 
 namespace Svg
 {
-    //TODO Need to split this enum into separate inherited enums for GradientCoordinateUnits, ClipPathCoordinateUnits, etc. as each should have its own converter since they have different defaults.
     /// <summary>
     /// Defines the various coordinate units certain SVG elements may use.
     /// </summary>
     [TypeConverter(typeof(SvgCoordinateUnitsConverter))]
     public enum SvgCoordinateUnits
     {
-        //TODO Inherit is not actually valid
-        Inherit,
-
         /// <summary>
         /// Indicates that the coordinate system of the owner element is to be used.
         /// </summary>

--- a/Source/Painting/SvgPatternServer.cs
+++ b/Source/Painting/SvgPatternServer.cs
@@ -17,8 +17,8 @@ namespace Svg
         private SvgUnit _y = SvgUnit.None;
         private SvgUnit _width = SvgUnit.None;
         private SvgUnit _height = SvgUnit.None;
-        private SvgCoordinateUnits _patternUnits = SvgCoordinateUnits.Inherit;
-        private SvgCoordinateUnits _patternContentUnits = SvgCoordinateUnits.Inherit;
+        private SvgCoordinateUnits? _patternUnits;
+        private SvgCoordinateUnits? _patternContentUnits;
         private SvgViewBox _viewBox;
 
         /// <summary>
@@ -67,7 +67,7 @@ namespace Svg
         [SvgAttribute("patternUnits")]
         public SvgCoordinateUnits PatternUnits
         {
-            get { return _patternUnits; }
+            get { return _patternUnits ?? SvgCoordinateUnits.ObjectBoundingBox; }
             set { _patternUnits = value; Attributes["patternUnits"] = value; }
         }
 
@@ -77,7 +77,7 @@ namespace Svg
         [SvgAttribute("patternContentUnits")]
         public SvgCoordinateUnits PatternContentUnits
         {
-            get { return _patternContentUnits; }
+            get { return _patternContentUnits ?? SvgCoordinateUnits.UserSpaceOnUse; }
             set { _patternContentUnits = value; Attributes["patternContentUnits"] = value; }
         }
 
@@ -167,8 +167,8 @@ namespace Svg
             var firstHeight = chain.Where(p => p.Height != null && p.Height != SvgUnit.None).FirstOrDefault();
             if (firstWidth == null || firstHeight == null)
                 return null;
-            var firstPatternUnit = chain.Where(p => p.PatternUnits != SvgCoordinateUnits.Inherit).FirstOrDefault();
-            var firstPatternContentUnit = chain.Where(p => p.PatternContentUnits != SvgCoordinateUnits.Inherit).FirstOrDefault();
+            var firstPatternUnit = chain.Where(p => p._patternUnits.HasValue).FirstOrDefault();
+            var firstPatternContentUnit = chain.Where(p => p._patternContentUnits.HasValue).FirstOrDefault();
             var firstViewBox = chain.Where(p => p.ViewBox != null && p.ViewBox != SvgViewBox.Empty).FirstOrDefault();
 
             var xUnit = firstX == null ? new SvgUnit(0f) : firstX.X;

--- a/Tests/Svg.UnitTests/EnumConvertersTests.cs
+++ b/Tests/Svg.UnitTests/EnumConvertersTests.cs
@@ -38,17 +38,12 @@ namespace Svg.UnitTests
             var convertFrom = enumConverter.GetMethod("ConvertFrom", new Type[] { typeof(object) });
             var convertTo = enumConverter.GetMethod("ConvertTo", new Type[] { typeof(object), typeof(Type) });
 
-            var defaultValue = convertFrom.Invoke(converter, new object[] { null });
-
             foreach (var expected in expectedList)
             {
                 var converted = convertFrom.Invoke(converter, new object[] { expected });
                 var result = convertTo.Invoke(converter, new object[] { converted, typeof(string) });
 
-                if (result != null)
-                    Assert.AreEqual(expected, result);
-                else
-                    Assert.AreEqual(defaultValue, converted);
+                Assert.AreEqual(expected, result);
             }
         }
     }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

Ref. #577 and #599.

#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->

As we can see from the following `TODO` comment, default values are determined by attributes.

https://github.com/vvvv/SVG/blob/40600c77bbd93c173694dbe14dfa7ff5ddb337e1/Source/DataTypes/EnumConverters.cs#L175

https://github.com/vvvv/SVG/blob/40600c77bbd93c173694dbe14dfa7ff5ddb337e1/Source/DataTypes/SvgCoordinateUnits.cs#L9

Default value is determined by property of attribute.
So, remove default values of `EnumConverters`.

https://github.com/vvvv/SVG/blob/40600c77bbd93c173694dbe14dfa7ff5ddb337e1/Source/Painting/SvgGradientServer.cs#L71

https://github.com/vvvv/SVG/blob/40600c77bbd93c173694dbe14dfa7ff5ddb337e1/Source/Clipping%20and%20Masking/SvgClipPath.cs#L20

#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
