### PR TITLE
Enable checking if PatternUnits or PatternContentUnits was actually set

### DIFF
--- a/Source/Painting/SvgPatternServer.cs
+++ b/Source/Painting/SvgPatternServer.cs
@@ -141,6 +141,24 @@ namespace Svg
         }
 
         /// <summary>
+        /// Check if <see cref="PatternUnits"/> property value was set.
+        /// </summary>
+        /// <returns>True if <see cref="PatternUnits"/> has value.</returns>
+        public bool HasPatternUnits()
+        {
+            return _patternUnits.HasValue;
+        }
+
+        /// <summary>
+        /// Check if <see cref="PatternContentUnits"/> property value was set.
+        /// </summary>
+        /// <returns>True if <see cref="PatternContentUnits"/> has value.</returns>
+        public bool HasPatternContentUnits()
+        {
+            return _patternContentUnits.HasValue;
+        }
+
+        /// <summary>
         /// Gets a <see cref="Brush"/> representing the current paint server.
         /// </summary>
         /// <param name="renderingElement">The owner <see cref="SvgVisualElement"/>.</param>


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
The https://github.com/vvvv/SVG/pull/668 actually broke Svg.Skia pattern rendering, did not see this as breaking at first. In order to correctly render pattern, pattern property inheritance must be used to check for inherited values. As #668 removed invalid `inherited` enum value it broke Svg.Skia as it does not have access to internal fields and those are necessary to provide information if actually PatternUnits or PatternContentUnits was set.

#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->
Adds HasPatternUnits() and HasPatternContentUnits() methods to check if field has actually a value.

#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
