### PR TITLE
Added enum converters for Filter Effects

### DIFF
--- a/Source/DataTypes/EnumConverters.cs
+++ b/Source/DataTypes/EnumConverters.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.Globalization;
 using System.Text.RegularExpressions;

--- a/Source/DataTypes/EnumConverters.cs
+++ b/Source/DataTypes/EnumConverters.cs
@@ -19,7 +19,7 @@ namespace Svg
     }
 
     // converts enums to lower case strings
-    public abstract class EnumBaseConverter<T> : BaseConverter
+    public class EnumBaseConverter<T> : BaseConverter
         where T : struct
     {
         public enum CaseHandling
@@ -33,8 +33,13 @@ namespace Svg
         public CaseHandling CaseHandlingMode { get; }
 
         /// <summary>Creates a new instance.</summary>
+        public EnumBaseConverter() : this(CaseHandling.CamelCase)
+        {
+        }
+
+        /// <summary>Creates a new instance.</summary>
         /// <param name="caseHandling">Defines if the value shall be converted to camelCase, lowercase or kebab-case.</param>
-        public EnumBaseConverter(CaseHandling caseHandling = CaseHandling.CamelCase)
+        public EnumBaseConverter(CaseHandling caseHandling)
         {
             CaseHandlingMode = caseHandling;
         }

--- a/Source/DataTypes/EnumConverters.cs
+++ b/Source/DataTypes/EnumConverters.cs
@@ -62,7 +62,6 @@ namespace Svg
             if (destinationType == typeof(string) && value is T)
             {
                 var stringValue = ((T)value).ToString();
-
                 if (CaseHandlingMode == CaseHandling.CamelCase)
                     return string.Format("{0}{1}", stringValue[0].ToString().ToLower(), stringValue.Substring(1));
 

--- a/Source/DataTypes/EnumConverters.cs
+++ b/Source/DataTypes/EnumConverters.cs
@@ -25,8 +25,8 @@ namespace Svg
     {
         public enum CaseHandling
         {
-            NoneCase,
             CamelCase,
+            PascalCase,
             LowerCase,
             KebabCase,
         }
@@ -63,11 +63,11 @@ namespace Svg
             {
                 var stringValue = ((T)value).ToString();
 
-                if (CaseHandlingMode == CaseHandling.NoneCase)
-                    return stringValue;
-
                 if (CaseHandlingMode == CaseHandling.CamelCase)
                     return string.Format("{0}{1}", stringValue[0].ToString().ToLower(), stringValue.Substring(1));
+
+                if (CaseHandlingMode == CaseHandling.PascalCase)
+                    return stringValue;
 
                 if (CaseHandlingMode == CaseHandling.KebabCase)
                     stringValue = Regex.Replace(stringValue, @"(\w)([A-Z])", "$1-$2", RegexOptions.CultureInvariant);
@@ -194,7 +194,7 @@ namespace Svg
 
     public sealed class SvgChannelSelectorConverter : EnumBaseConverter<SvgChannelSelector>
     {
-        public SvgChannelSelectorConverter() : base(CaseHandling.NoneCase) { }
+        public SvgChannelSelectorConverter() : base(CaseHandling.PascalCase) { }
     }
 
     public sealed class SvgMorphologyOperatorConverter : EnumBaseConverter<SvgMorphologyOperator> { }

--- a/Source/DataTypes/EnumConverters.cs
+++ b/Source/DataTypes/EnumConverters.cs
@@ -35,7 +35,7 @@ namespace Svg
         public CaseHandling CaseHandlingMode { get; }
 
         /// <summary>Creates a new instance.</summary>
-        /// <param name="caseHandling">Defines if the value shall be converted to camelCase, lowercase or kebab-case.</param>
+        /// <param name="caseHandling">Defines if the value shall be converted to camelCase, PascalCase, lowercase or kebab-case.</param>
         public EnumBaseConverter(CaseHandling caseHandling = CaseHandling.CamelCase)
         {
             CaseHandlingMode = caseHandling;

--- a/Source/DataTypes/EnumConverters.cs
+++ b/Source/DataTypes/EnumConverters.cs
@@ -199,7 +199,7 @@ namespace Svg
 
     public sealed class SvgChannelSelectorConverter : EnumBaseConverter<SvgChannelSelector>
     {
-        public SvgChannelSelectorConverter() : base(CaseHandling.LowerCase) { }
+        public SvgChannelSelectorConverter() : base(CaseHandling.NoneCase) { }
     }
 
     public sealed class SvgMorphologyOperatorConverter : EnumBaseConverter<SvgMorphologyOperator> { }

--- a/Source/DataTypes/EnumConverters.cs
+++ b/Source/DataTypes/EnumConverters.cs
@@ -25,6 +25,7 @@ namespace Svg
     {
         public enum CaseHandling
         {
+            NoneCase,
             CamelCase,
             LowerCase,
             KebabCase,
@@ -66,6 +67,10 @@ namespace Svg
             if (destinationType == typeof(string) && value is T)
             {
                 var stringValue = ((T)value).ToString();
+
+                if (CaseHandlingMode == CaseHandling.NoneCase)
+                    return stringValue;
+
                 if (CaseHandlingMode == CaseHandling.CamelCase)
                     return string.Format("{0}{1}", stringValue[0].ToString().ToLower(), stringValue.Substring(1));
 
@@ -192,7 +197,10 @@ namespace Svg
 
     public sealed class SvgEdgeModeConverter : EnumBaseConverter<SvgEdgeMode> { }
 
-    public sealed class SvgChannelSelectorConverter : EnumBaseConverter<SvgChannelSelector> { }
+    public sealed class SvgChannelSelectorConverter : EnumBaseConverter<SvgChannelSelector>
+    {
+        public SvgChannelSelectorConverter() : base(CaseHandling.LowerCase) { }
+    }
 
     public sealed class SvgMorphologyOperatorConverter : EnumBaseConverter<SvgMorphologyOperator> { }
 

--- a/Source/DataTypes/EnumConverters.cs
+++ b/Source/DataTypes/EnumConverters.cs
@@ -1,4 +1,4 @@
-using System;
+﻿﻿using System;
 using System.ComponentModel;
 using System.Globalization;
 using System.Text.RegularExpressions;

--- a/Source/DataTypes/EnumConverters.cs
+++ b/Source/DataTypes/EnumConverters.cs
@@ -1,4 +1,4 @@
-﻿﻿using System;
+﻿using System;
 using System.ComponentModel;
 using System.Globalization;
 using System.Text.RegularExpressions;
@@ -31,7 +31,7 @@ namespace Svg
             KebabCase,
         }
 
-        /// <summary>Defines if the enum literal shall be converted to camelCase, lowercase or kebab-case.</summary>
+        /// <summary>Defines if the enum literal shall be converted to camelCase, PascalCase or kebab-case.</summary>
         public CaseHandling CaseHandlingMode { get; }
 
         /// <summary>Creates a new instance.</summary>

--- a/Source/DataTypes/EnumConverters.cs
+++ b/Source/DataTypes/EnumConverters.cs
@@ -35,13 +35,8 @@ namespace Svg
         public CaseHandling CaseHandlingMode { get; }
 
         /// <summary>Creates a new instance.</summary>
-        public EnumBaseConverter() : this(CaseHandling.CamelCase)
-        {
-        }
-
-        /// <summary>Creates a new instance.</summary>
         /// <param name="caseHandling">Defines if the value shall be converted to camelCase, lowercase or kebab-case.</param>
-        public EnumBaseConverter(CaseHandling caseHandling)
+        public EnumBaseConverter(CaseHandling caseHandling = CaseHandling.CamelCase)
         {
             CaseHandlingMode = caseHandling;
         }

--- a/Source/DataTypes/EnumConverters.cs
+++ b/Source/DataTypes/EnumConverters.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using Svg.DataTypes;
+using Svg.FilterEffects;
 
 namespace Svg
 {
@@ -19,7 +20,7 @@ namespace Svg
     }
 
     // converts enums to lower case strings
-    public class EnumBaseConverter<T> : BaseConverter
+    public abstract class EnumBaseConverter<T> : BaseConverter
         where T : struct
     {
         public enum CaseHandling
@@ -177,6 +178,27 @@ namespace Svg
     }
 
     public sealed class SvgTextTransformationConverter : EnumBaseConverter<SvgTextTransformation> { }
+
+    public sealed class SvgBlendModeConverter : EnumBaseConverter<SvgBlendMode>
+    {
+        public SvgBlendModeConverter() : base(CaseHandling.KebabCase) { }
+    }
+
+    public sealed class SvgColourMatrixTypeConverter : EnumBaseConverter<SvgColourMatrixType> { }
+
+    public sealed class SvgComponentTransferTypeConverter : EnumBaseConverter<SvgComponentTransferType> { }
+
+    public sealed class SvgCompositeOperatorConverter : EnumBaseConverter<SvgCompositeOperator> { }
+
+    public sealed class SvgEdgeModeConverter : EnumBaseConverter<SvgEdgeMode> { }
+
+    public sealed class SvgChannelSelectorConverter : EnumBaseConverter<SvgChannelSelector> { }
+
+    public sealed class SvgMorphologyOperatorConverter : EnumBaseConverter<SvgMorphologyOperator> { }
+
+    public sealed class SvgStitchTypeConverter : EnumBaseConverter<SvgStitchType> { }
+
+    public sealed class SvgTurbulenceTypeConverter : EnumBaseConverter<SvgTurbulenceType> { }
 
     public static class Enums
     {

--- a/Source/Filter Effects/feBlend/SvgBlendMode.cs
+++ b/Source/Filter Effects/feBlend/SvgBlendMode.cs
@@ -2,7 +2,7 @@
 
 namespace Svg.FilterEffects
 {
-    [TypeConverter(typeof(EnumBaseConverter<SvgBlendMode>))]
+    [TypeConverter(typeof(SvgBlendModeConverter))]
     public enum SvgBlendMode
     {
         Normal,

--- a/Source/Filter Effects/feColourMatrix/SvgColourMatrixType.cs
+++ b/Source/Filter Effects/feColourMatrix/SvgColourMatrixType.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace Svg.FilterEffects
 {
-    [TypeConverter(typeof(EnumBaseConverter<SvgColourMatrixType>))]
+    [TypeConverter(typeof(SvgColourMatrixTypeConverter))]
     public enum SvgColourMatrixType
     {
         Matrix,

--- a/Source/Filter Effects/feComponentTransfer/SvgComponentTransferType.cs
+++ b/Source/Filter Effects/feComponentTransfer/SvgComponentTransferType.cs
@@ -2,7 +2,7 @@
 
 namespace Svg.FilterEffects
 {
-    [TypeConverter(typeof(EnumBaseConverter<SvgComponentTransferType>))]
+    [TypeConverter(typeof(SvgComponentTransferTypeConverter))]
     public enum SvgComponentTransferType
     {
         Identity,

--- a/Source/Filter Effects/feComposite/SvgCompositeOperator.cs
+++ b/Source/Filter Effects/feComposite/SvgCompositeOperator.cs
@@ -2,7 +2,7 @@
 
 namespace Svg.FilterEffects
 {
-    [TypeConverter(typeof(EnumBaseConverter<SvgCompositeOperator>))]
+    [TypeConverter(typeof(SvgCompositeOperatorConverter))]
     public enum SvgCompositeOperator
     {
         Over,

--- a/Source/Filter Effects/feConvolveMatrix/SvgEdgeMode.cs
+++ b/Source/Filter Effects/feConvolveMatrix/SvgEdgeMode.cs
@@ -2,7 +2,7 @@
 
 namespace Svg.FilterEffects
 {
-    [TypeConverter(typeof(EnumBaseConverter<SvgEdgeMode>))]
+    [TypeConverter(typeof(SvgEdgeModeConverter))]
     public enum SvgEdgeMode
     {
         Duplicate,

--- a/Source/Filter Effects/feDisplacementMap/SvgChannelSelector.cs
+++ b/Source/Filter Effects/feDisplacementMap/SvgChannelSelector.cs
@@ -2,7 +2,7 @@
 
 namespace Svg.FilterEffects
 {
-    [TypeConverter(typeof(EnumBaseConverter<SvgChannelSelector>))]
+    [TypeConverter(typeof(SvgChannelSelectorConverter))]
     public enum SvgChannelSelector
     {
         R,

--- a/Source/Filter Effects/feMorphology/SvgMorphologyOperator.cs
+++ b/Source/Filter Effects/feMorphology/SvgMorphologyOperator.cs
@@ -2,7 +2,7 @@
 
 namespace Svg.FilterEffects
 {
-    [TypeConverter(typeof(EnumBaseConverter<SvgMorphologyOperator>))]
+    [TypeConverter(typeof(SvgMorphologyOperatorConverter))]
     public enum SvgMorphologyOperator
     {
         Erode,

--- a/Source/Filter Effects/feTurbulence/SvgStitchType.cs
+++ b/Source/Filter Effects/feTurbulence/SvgStitchType.cs
@@ -2,7 +2,7 @@
 
 namespace Svg.FilterEffects
 {
-    [TypeConverter(typeof(EnumBaseConverter<SvgStitchType>))]
+    [TypeConverter(typeof(SvgStitchTypeConverter))]
     public enum SvgStitchType
     {
         Stitch,

--- a/Source/Filter Effects/feTurbulence/SvgTurbulenceType.cs
+++ b/Source/Filter Effects/feTurbulence/SvgTurbulenceType.cs
@@ -2,7 +2,7 @@
 
 namespace Svg.FilterEffects
 {
-    [TypeConverter(typeof(EnumBaseConverter<SvgTurbulenceType>))]
+    [TypeConverter(typeof(SvgTurbulenceTypeConverter))]
     public enum SvgTurbulenceType
     {
         FractalNoise,

--- a/Tests/Svg.UnitTests/EnumConvertersTests.cs
+++ b/Tests/Svg.UnitTests/EnumConvertersTests.cs
@@ -32,6 +32,15 @@ namespace Svg.UnitTests
         [TestCase(typeof(SvgFontStretchConverter), "normal", "wider", "narrower", "ultra-condensed", "extra-condensed", "condensed", "semi-condensed", "semi-expanded", "expanded", "extra-expanded", "ultra-expanded", "inherit")]
         [TestCase(typeof(SvgFontWeightConverter), "normal", "bold", "bolder", "lighter", "100", "200", "300", "400", "500", "600", "700", "800", "900", "inherit")]
         [TestCase(typeof(SvgTextTransformationConverter), "none", "capitalize", "uppercase", "lowercase", "inherit")]
+        [TestCase(typeof(SvgBlendModeConverter), "normal", "multiply", "screen", "overlay", "darken", "lighten", "color-dodge", "color-burn", "hard-light", "soft-light", "difference", "exclusion", "hue", "saturation", "color", "luminosity")]
+        [TestCase(typeof(SvgColourMatrixTypeConverter), "matrix", "saturate", "hueRotate", "luminanceToAlpha")]
+        [TestCase(typeof(SvgComponentTransferTypeConverter), "identity", "table", "discrete", "linear", "gamma")]
+        [TestCase(typeof(SvgCompositeOperatorConverter), "over", "in", "out", "atop", "xor", "arithmetic")]
+        [TestCase(typeof(SvgEdgeModeConverter), "duplicate", "wrap", "none")]
+        [TestCase(typeof(SvgChannelSelectorConverter), "R", "G", "B", "A")]
+        [TestCase(typeof(SvgMorphologyOperatorConverter), "erode", "dilate")]
+        [TestCase(typeof(SvgStitchTypeConverter), "stitch", "noStitch")]
+        [TestCase(typeof(SvgTurbulenceTypeConverter), "fractalNoise", "turbulence")]
         public void TestConvert(Type enumConverter, params string[] expectedList)
         {
             var converter = Activator.CreateInstance(enumConverter);


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->
When EnumBaseConverter is using directly it fails as its abstract class and does not have default empty constructor:
https://github.com/vvvv/SVG/search?q=EnumBaseConverter&unscoped_q=EnumBaseConverter

#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
