### PR TITLE
Reference assemblies

### DIFF
--- a/Source/Svg.csproj
+++ b/Source/Svg.csproj
@@ -76,6 +76,10 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.2'">
     <PackageReference Include="System.Drawing.Common">
       <Version>4.7.0</Version>

--- a/Tests/Svg.UnitTests/Svg.UnitTests.csproj
+++ b/Tests/Svg.UnitTests/Svg.UnitTests.csproj
@@ -74,10 +74,11 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Source\SVG.csproj" />
+    <ProjectReference Include="..\..\Source\Svg.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.2'">


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->

Adds `ReferenceAssemblies` to enable building without `.NET Framework` using dotnet tools on e.g. Linux/macOS.
```bash
dotnet build Source/Svg.csproj
dotnet test Tests/Svg.UnitTests/Svg.UnitTests.csproj
```

More info: https://github.com/Microsoft/dotnet/tree/master/releases/reference-assemblies

#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
