### PR TITLE
Revert "Enable checking if PatternUnits or PatternContentUnits was actually set

### DIFF
--- a/Source/Painting/SvgPatternServer.cs
+++ b/Source/Painting/SvgPatternServer.cs
@@ -141,24 +141,6 @@ namespace Svg
         }
 
         /// <summary>
-        /// Check if <see cref="PatternUnits"/> property value was set.
-        /// </summary>
-        /// <returns>True if <see cref="PatternUnits"/> has value.</returns>
-        public bool HasPatternUnits()
-        {
-            return _patternUnits.HasValue;
-        }
-
-        /// <summary>
-        /// Check if <see cref="PatternContentUnits"/> property value was set.
-        /// </summary>
-        /// <returns>True if <see cref="PatternContentUnits"/> has value.</returns>
-        public bool HasPatternContentUnits()
-        {
-            return _patternContentUnits.HasValue;
-        }
-
-        /// <summary>
         /// Gets a <see cref="Brush"/> representing the current paint server.
         /// </summary>
         /// <param name="renderingElement">The owner <see cref="SvgVisualElement"/>.</param>


### PR DESCRIPTION
This reverts commit df64dd3a73115ea3f633927172d79ae8c28908ee.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

Just revert #669

https://github.com/vvvv/SVG/pull/669#issuecomment-586857829

#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->

#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
