### PR TITLE
Do not set Overflow attribute inside.

### DIFF
--- a/Source/Document Structure/SvgFragment.cs
+++ b/Source/Document Structure/SvgFragment.cs
@@ -89,7 +89,7 @@ namespace Svg
         [SvgAttribute("overflow")]
         public virtual SvgOverflow Overflow
         {
-            get { return GetAttribute<SvgOverflow>("overflow", false); }
+            get { return GetAttribute("overflow", false, SvgOverflow.Hidden); }
             set { Attributes["overflow"] = value; }
         }
 

--- a/Source/Painting/SvgPatternServer.cs
+++ b/Source/Painting/SvgPatternServer.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Drawing2D;
@@ -105,7 +105,7 @@ namespace Svg
         [SvgAttribute("overflow")]
         public SvgOverflow Overflow
         {
-            get { return GetAttribute<SvgOverflow>("overflow", false); }
+            get { return GetAttribute("overflow", false, SvgOverflow.Hidden); }
             set { Attributes["overflow"] = value; }
         }
 

--- a/Source/SvgDocument.cs
+++ b/Source/SvgDocument.cs
@@ -36,6 +36,11 @@ namespace Svg
 
         private Dictionary<string, IEnumerable<SvgFontFace>> _fontDefns = null;
 
+        public override SvgOverflow Overflow
+        {
+            get { return GetAttribute("overflow", false, SvgOverflow.Visible); }
+        }
+
         private static int GetSystemDpi()
         {
             bool isWindows;
@@ -622,9 +627,6 @@ namespace Svg
 
             using (var renderer = SvgRenderer.FromImage(bitmap))
             {
-                // EO, 2014-12-05: Requested to ensure proper zooming out (reduce size). Otherwise it clip the image.
-                this.Overflow = SvgOverflow.Auto;
-
                 var boundable = new GenericBoundable(0, 0, bitmap.Width, bitmap.Height);
                 this.Draw(renderer, boundable);
             }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->

This PR has eliminated all attributes change inside.

Eliminates side effects of calling `Draw(Bitmap)` method.

#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
