### PR TITLE
Added Href property to SvgFilter class

### DIFF
--- a/Source/Filter Effects/SvgFilter.cs
+++ b/Source/Filter Effects/SvgFilter.cs
@@ -67,6 +67,16 @@ namespace Svg.FilterEffects
         }
 
         /// <summary>
+        /// Gets or sets reference to another filter element within the current document fragment.
+        /// </summary>
+        [SvgAttribute("href", SvgAttributeAttribute.XLinkNamespace)]
+        public Uri Href
+        {
+            get { return GetAttribute<Uri>("href", false); }
+            set { Attributes["href"] = value; }
+        }
+
+        /// <summary>
         /// Renders the <see cref="SvgElement"/> and contents to the specified <see cref="ISvgRenderer"/> object.
         /// </summary>
         /// <param name="renderer">The <see cref="ISvgRenderer"/> object to render to.</param>

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -12,6 +12,7 @@ The release versions are NuGet releases.
 * added FontStretch property to SvgElement (see [PR #654](https://github.com/vvvv/SVG/pull/654))
 * moved ColorInterpolationFilters property to SvgElement because its a presentation attribute (see [PR #667](https://github.com/vvvv/SVG/pull/667))
 * added ColorInterpolation property to SvgElement (see [PR #667](https://github.com/vvvv/SVG/pull/667))
+* added Href property to SvgFilter (see [PR #679](https://github.com/vvvv/SVG/pull/679))
 
 ### Fixes
 * fixed CoordinateParser handling of invalid state (see [PR #640](https://github.com/vvvv/SVG/pull/640))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->
Added Href property to SvgFilter class

```
xlink:href = "<iri>"
An IRI reference to another ‘filter’ element within the current SVG document fragment. Any attributes which are defined on the referenced ‘filter’ element which are not defined on this element are inherited by this element. If this element has no defined filter nodes, and the referenced element has defined filter nodes (possibly due to its own ‘xlink:href’ attribute), then this element inherits the filter nodes defined from the referenced ‘filter’ element. Inheritance can be indirect to an arbitrary level; thus, if the referenced ‘filter’ element inherits attributes or its filter node specification due to its own ‘xlink:href’ attribute, then the current element can inherit those attributes or filter node specifications.
Animatable: yes.
```

https://www.w3.org/TR/SVG11/filters.html#FilterElement

#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
