### PR TITLE
Added Net4 CompileConstant

### DIFF
--- a/Source/Svg.csproj
+++ b/Source/Svg.csproj
@@ -53,7 +53,7 @@
 
   <PropertyGroup Condition="'$(TargetFramework)'=='net452'">
     <Title>Svg for .Net Framework 4.5.2</Title>
-    <DefineConstants>$(DefineConstants);NETFULL;NET452</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETFULL;NET452;Net4</DefineConstants>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Addresses #696 - a few functions that are only useful in the .net Framework version are gated with a compile constant (`Net4`) that is not defined in the current version. 

#### Any other comments?

Alternatively, the `#if`s could use the "correct" compile constants but I considered that doing it this way is nicer. 