### PR TITLE
Fix issue #704. 

### DIFF
--- a/Source/Text/SvgTextBase.cs
+++ b/Source/Text/SvgTextBase.cs
@@ -270,6 +270,7 @@ namespace Svg
                 }
                 if (Transforms != null && Transforms.Count > 0)
                 {
+                    path = path.Clone() as GraphicsPath;    // fix issue #704
                     using (var matrix = Transforms.GetMatrix())
                         path.Transform(matrix);
                 }

--- a/Tests/Svg.UnitTests/BoundsTests.cs
+++ b/Tests/Svg.UnitTests/BoundsTests.cs
@@ -36,6 +36,17 @@ namespace Svg.UnitTests
         }
 
         [Test]
+        public void TestTextBounds()
+        {
+            // x="10" y="30" font-family="Tahoma" font-size="15pt"  content="VVVV-svg"
+            AssertEqualBounds("text", 9.92f, 15.46f, 83.69f, 18.67f);
+            // additional translation(10, 10)
+            AssertEqualBounds("text-xlate", 19.92f, 24.8f, 133.95f, 19.33f);
+            // additional rotation(30)
+            AssertEqualBounds("text-rot", -2.08f, 18.34f, 102.46f, 71.01f);
+        }
+
+        [Test]
         public void TestGroupBounds()
         {
             // all lines from TestLineBounds()
@@ -60,6 +71,23 @@ namespace Svg.UnitTests
         public void TestRotatedGroupBounds()
         {
             AssertEqualBounds("lines-rotated", -45.5f, 9.5f, 86, 31);
+        }
+
+        [Test]
+        public void TestBoundsIndempotent()
+        {
+            // ensure that accessing the Bounds property returns the same value when called repeatedly.
+            AssertEqualBounds("lines-rotated", -45.5f, 9.5f, 86, 31);
+            AssertEqualBounds("lines-rotated", -45.5f, 9.5f, 86, 31);
+
+            AssertEqualBounds("text-rot", -2.08f, 18.34f, 102.46f, 71.01f);
+            AssertEqualBounds("text-rot", -2.08f, 18.34f, 102.46f, 71.01f);
+
+            AssertEqualBounds("rect-rot", -50.5f, 9.5f, 21f, 11f);
+            AssertEqualBounds("rect-rot", -50.5f, 9.5f, 21f, 11f);
+
+            AssertEqualBounds("line-xform", 19.5f, -40.5f, 21, 21);
+            AssertEqualBounds("line-xform", 19.5f, -40.5f, 21, 21);
         }
 
         private void AssertEqualBounds(string elementId, float x, float y, float width, float height)

--- a/Tests/Svg.UnitTests/Resources/Issue281_Bounds/BoundsTest.svg
+++ b/Tests/Svg.UnitTests/Resources/Issue281_Bounds/BoundsTest.svg
@@ -26,4 +26,9 @@
     <rect id="rect-xlate" x="10" y="30" width="10" height="20" transform="translate(10, 10)" />
     <rect id="rect-rot" x="10" y="30" width="10" height="20" transform="rotate(90)" />
   </g>
+  <g id="texts">
+    <text id="text" x="10" y="30" font-family="Tahoma" font-size="15pt">VVVV-svg</text>
+    <text id="text-xlate" x="10" y="30" font-family="Tahoma" font-size="15pt" transform="translate(10, 10)">VVVV-svg-xlate</text>
+    <text id="text-rot" x="10" y="30" font-family="Tahoma" font-size="15pt" transform="rotate(30)" >VVVV-svg-rot</text>
+  </g>
 </svg>


### PR DESCRIPTION
Transform a copy of graphics path when calculating text bounds.

Includes issue repro unit tests.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #704

#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->

#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
