### PR TITLE
Disable PrivateFonts property on NetStandard build

### DIFF
--- a/Source/SvgElementStyle.cs
+++ b/Source/SvgElementStyle.cs
@@ -469,8 +469,9 @@ namespace Svg
                 return new SvgFontDefn(font, fontSize, OwnerDocument.Ppi);
             }
         }
-
+#if !NETSTANDARD20
         public static System.Drawing.Text.PrivateFontCollection PrivateFonts = new System.Drawing.Text.PrivateFontCollection();
+#endif
         public static object ValidateFontFamily(string fontFamilyList, SvgDocument doc)
         {
             // Split font family list on "," and then trim start and end spaces and quotes.
@@ -485,8 +486,10 @@ namespace Svg
                 if (doc != null && doc.FontDefns().TryGetValue(f, out sFaces)) return sFaces;
                 family = SvgFontManager.FindFont(f);
                 if (family != null) return family;
+#if !NETSTANDARD20
                 family = PrivateFonts.Families.FirstOrDefault(ff => string.Equals(ff.Name, f, StringComparison.OrdinalIgnoreCase));
                 if (family != null) return family;
+#endif
                 switch (f.ToLower())
                 {
                     case "serif":

--- a/Tests/Svg.UnitTests/PrivateFontsTests.cs
+++ b/Tests/Svg.UnitTests/PrivateFontsTests.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿#if !NETSTANDARD20
+using NUnit.Framework;
 using System.Drawing.Text;
 using System.Runtime.InteropServices;
 
@@ -38,3 +39,4 @@ namespace Svg.UnitTests
         }
     }
 }
+#endif


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

It's not supported on Xamarin.Forms Android/iOS see https://github.com/wieslawsoltes/Svg.Skia/issues/21#issuecomment-613903911

#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->

#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
