### PR TITLE
Fixing UWP Crash

### DIFF
--- a/Source/SvgDocument.cs
+++ b/Source/SvgDocument.cs
@@ -67,13 +67,13 @@ namespace Svg
             }
         }
 
-        [DllImport("gdi32.dll")]
+        [DllImport("gdi32.dll", ExactSpelling = true)]
         private static extern int GetDeviceCaps(IntPtr hdc, int nIndex);
 
-        [DllImport("user32.dll")]
+        [DllImport("user32.dll", ExactSpelling = true)]
         private static extern IntPtr GetDC(IntPtr hWnd);
 
-        [DllImport("user32.dll")]
+        [DllImport("user32.dll", ExactSpelling = true)]
         private static extern int ReleaseDC(IntPtr hWnd, IntPtr hDC);
 
         internal Dictionary<string, IEnumerable<SvgFontFace>> FontDefns()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
This crashes in UWP Release Mode but works in UWP Debug Mode 
var dpi = SvgDocument.PointsPerInch;

#### What does this implement/fix? Explain your changes.
Changes from this

```
        [DllImport("gdi32.dll")]
        private static extern int GetDeviceCaps(IntPtr hdc, int nIndex);

        [DllImport("user32.dll")]
        private static extern IntPtr GetDC(IntPtr hWnd);

        [DllImport("user32.dll")]
        private static extern int ReleaseDC(IntPtr hWnd, IntPtr hDC);
```


to This

```
        [DllImport("gdi32.dll", ExactSpelling = true)]
        private static extern int GetDeviceCaps(IntPtr hdc, int nIndex);

        [DllImport("user32.dll", ExactSpelling = true)]
        private static extern IntPtr GetDC(IntPtr hWnd);

        [DllImport("user32.dll", ExactSpelling = true)]
        private static extern int ReleaseDC(IntPtr hWnd, IntPtr hDC);
```
Than it Works in UWP Release Mode and doesn't crash

#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
