### PR TITLE
Uwp fix without interops

### DIFF
--- a/Source/SvgDocument.cs
+++ b/Source/SvgDocument.cs
@@ -53,12 +53,20 @@ namespace Svg
 
             if (isWindows)
             {
-                // NOTE: starting with Windows 8.1, the DPI is no longer system-wide but screen-specific
-                IntPtr hDC = GetDC(IntPtr.Zero);
-                const int LOGPIXELSY = 90;
-                int result = GetDeviceCaps(hDC, LOGPIXELSY);
-                ReleaseDC(IntPtr.Zero, hDC);
-                return result;
+                try
+                {
+                    // NOTE: starting with Windows 8.1, the DPI is no longer system-wide but screen-specific
+                    IntPtr hDC = GetDC(IntPtr.Zero);
+                    const int LOGPIXELSY = 90;
+                    int result = GetDeviceCaps(hDC, LOGPIXELSY);
+                    ReleaseDC(IntPtr.Zero, hDC);
+                    return result;
+                }	
+                catch (TypeLoadException)	
+                {	
+                    // for UWP Release mode when standard is referenced	
+                    return 96;	
+                }
             }
             else
             {


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Fixes Crash in UWP Release Mode

#### Any other comments?
  
Is used for handling interop Exceptions when not Xamarin.Essentials is detected.

```
                catch (TypeLoadException)
                {
                    // for UWP Release mode when standard is referenced	
                    return 96;
                }
```
Is used for detecting if Xamarin.Essntials Assembly is available.
```
var deviceDisplayType = Type.GetType("Xamarin.Essentials.DeviceDisplay, Xamarin.Essentials, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null");
```