### PR TITLE
Fix SvgNumberCollection Clone method returning invalid collection type

### DIFF
--- a/Source/DataTypes/SvgNumberCollection.cs
+++ b/Source/DataTypes/SvgNumberCollection.cs
@@ -15,10 +15,10 @@ namespace Svg
     {
         public object Clone()
         {
-            var points = new SvgPointCollection();
+            var numbers = new SvgNumberCollection();
             foreach (var point in this)
-                points.Add(point);
-            return points;
+                numbers.Add(point);
+            return numbers;
         }
 
         public override string ToString()

--- a/Tests/Svg.UnitTests/SvgNumberCollectionTests.cs
+++ b/Tests/Svg.UnitTests/SvgNumberCollectionTests.cs
@@ -31,5 +31,12 @@ namespace Svg.UnitTests
             var collection = (SvgNumberCollection)new SvgNumberCollectionConverter().ConvertFrom(value);
             Assert.AreEqual("1.6 3.2 1.2 5", collection.ToString());
         }
+
+        [Test]
+        public void CloneReturnsValidObjectType()
+        {
+            var collection = new SvgNumberCollection();
+            Assert.IsInstanceOf(typeof(SvgNumberCollection), collection.Clone());
+        }
     }
 }

--- a/Tests/Svg.UnitTests/SvgPointCollectionTests.cs
+++ b/Tests/Svg.UnitTests/SvgPointCollectionTests.cs
@@ -15,5 +15,12 @@ namespace Svg.UnitTests
             };
             Assert.AreEqual("1.6,3.2 1.2,5", collection.ToString());
         }
+
+        [Test]
+        public void CloneReturnsValidObjectType()
+        {
+            var collection = new SvgPointCollection();
+            Assert.IsInstanceOf(typeof(SvgPointCollection), collection.Clone());
+        }
     }
 }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->
Fixe SvgNumberCollection Clone method returning invalid collection type.

#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
