### PR TITLE
Fix: #746 'Error with duplicate ColorConverter.cs in Svg.dll and .NET Standard 2.1' issue.

### DIFF
--- a/Source/Svg.csproj
+++ b/Source/Svg.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp2.2;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp2.2;net452</TargetFrameworks>
     <PackageLicenseExpression>MS-PL</PackageLicenseExpression>
     <RootNamespace>Svg</RootNamespace>
     <AssemblyName>Svg</AssemblyName>
@@ -63,12 +63,17 @@
     <Title>Svg for .Net Core 2.2</Title>
     <DefineConstants>$(DefineConstants);NETCORE;NETCORE22</DefineConstants>
   </PropertyGroup>
-  
+
   <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <Title>Svg for .Net Standard 2.0</Title>
     <DefineConstants>$(DefineConstants);NETSTANDARD;NETSTANDARD20</DefineConstants>
   </PropertyGroup>
-  
+
+  <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.1'">
+    <Title>Svg for .Net Standard 2.1</Title>
+    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup Condition="'$(TargetFramework)'=='net452'">
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -91,7 +96,7 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="System.Drawing.Common">
       <Version>4.7.0</Version>
     </PackageReference>
@@ -101,12 +106,11 @@
   </ItemGroup>
 
   <!-- Mac specific include -->
-  
+
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.2'">
     <PackageReference Include="runtime.osx.10.10-x64.CoreCompat.System.Drawing" Version="5.8.64" />
   </ItemGroup>
- 
-  
+
   <ItemGroup>
     <Compile Remove=".\External\ExCSS\Parser.generated.cs" />
     <Compile Remove=".\External\ExCSS\ParserX.cs" />

--- a/Source/SvgFontManager.cs
+++ b/Source/SvgFontManager.cs
@@ -35,7 +35,7 @@ namespace Svg
         {
             families.AddRange(FontFamily.Families);
 
-#if !NETSTANDARD20
+#if !NETSTANDARD
             using (var privateFontCollection = new PrivateFontCollection())
             {
                 foreach (var path in PrivateFontPathList)

--- a/Tests/Svg.UnitTests/PrivateFontsTests.cs
+++ b/Tests/Svg.UnitTests/PrivateFontsTests.cs
@@ -18,7 +18,7 @@ namespace Svg.UnitTests
         private const string PrivateFontSvg = "Issue204_PrivateFont.Text.svg";
         private const string PrivateFont = "Issue204_PrivateFont.BrushScriptMT2.ttf";
 
-#if NETSTANDARD20
+#if NETSTANDARD
         // Private font does not work if .NET Standard.
         protected override int ExpectedSize { get { return 3000; } } // 3155
 #else

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -10,6 +10,7 @@ The release versions are NuGet releases.
 ### Fixes
 * fixed filter Inherited (see [#541](https://github.com/vvvv/SVG/issues/541) and [PR #689](https://github.com/vvvv/SVG/pull/689))
 * fixed calculate required layout rectangle (see [#732](https://github.com/vvvv/SVG/issues/732) and [PR #741](https://github.com/vvvv/SVG/pull/741))
+* fixed build error in .NET Standard 2.1 (see [#746](https://github.com/vvvv/SVG/issues/746) and [PR #748](https://github.com/vvvv/SVG/pull/748))
 
 ## [Version 3.1.1](https://www.nuget.org/packages/Svg/3.1.1)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

Fixes #746

Ref. #630

#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->

#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
