### PR TITLE
Handle element namespaces directly

### DIFF
--- a/Source/Document Structure/SvgFragment.cs
+++ b/Source/Document Structure/SvgFragment.cs
@@ -1,7 +1,6 @@
-using System;
+﻿using System;
 using System.Drawing;
 using System.Drawing.Drawing2D;
-using System.Xml;
 
 namespace Svg
 {
@@ -17,7 +16,7 @@ namespace Svg
         /// <summary>
         /// Gets the SVG namespace string.
         /// </summary>
-        public static readonly Uri Namespace = new Uri(SvgAttributeAttribute.SvgNamespace);
+        public static readonly Uri Namespace = new Uri(SvgNamespace.UriString);
 
         PointF ISvgBoundable.Location
         {

--- a/Source/NonSvgElement.cs
+++ b/Source/NonSvgElement.cs
@@ -1,4 +1,4 @@
-namespace Svg
+﻿namespace Svg
 {
     public class NonSvgElement : SvgElement
     {
@@ -6,9 +6,10 @@ namespace Svg
         {
         }
 
-        public NonSvgElement(string elementName)
+        public NonSvgElement(string elementName, string elementNamespace)
         {
             ElementName = elementName;
+            ElementNamespace = elementNamespace;
         }
 
         public override SvgElement DeepCopy()

--- a/Source/SvgAttributeAttribute.cs
+++ b/Source/SvgAttributeAttribute.cs
@@ -1,6 +1,5 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Svg
 {
@@ -10,10 +9,6 @@ namespace Svg
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Event)]
     public class SvgAttributeAttribute : Attribute
     {
-        /// <summary>
-        /// Gets a <see cref="string"/> containing the XLink namespace (http://www.w3.org/1999/xlink).
-        /// </summary>
-        public const string SvgNamespace = "http://www.w3.org/2000/svg";
         public const string XLinkPrefix = "xlink";
         public const string XLinkNamespace = "http://www.w3.org/1999/xlink";
         public const string XmlPrefix = "xml";
@@ -21,7 +16,6 @@ namespace Svg
 
         public static readonly List<KeyValuePair<string, string>> Namespaces = new List<KeyValuePair<string, string>>()
                                                                             {
-                                                                                new KeyValuePair<string, string>(string.Empty, SvgNamespace),
                                                                                 new KeyValuePair<string, string>(XLinkPrefix, XLinkNamespace),
                                                                                 new KeyValuePair<string, string>(XmlPrefix, XmlNamespace)
                                                                             };
@@ -48,43 +42,25 @@ namespace Svg
         /// <summary>
         /// Gets the name of the SVG attribute.
         /// </summary>
-        public string NamespaceAndName
-        {
-            get
-            {
-                if (NameSpace == SvgNamespace)
-                    return Name;
-                return Namespaces.First(x => x.Value == NameSpace).Key + ":" + Name;
-            }
-        }
-
-        /// <summary>
-        /// Gets the name of the SVG attribute.
-        /// </summary>
-        public string Name { get; private set; }
+        public string Name { get; }
 
         /// <summary>
         /// Gets the namespace of the SVG attribute.
         /// </summary>
-        public string NameSpace { get; private set; }
+        public string NameSpace { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SvgAttributeAttribute"/> class.
         /// </summary>
         internal SvgAttributeAttribute()
-        {
-            Name = string.Empty;
-        }
+            : this(string.Empty) { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SvgAttributeAttribute"/> class with the specified attribute name.
         /// </summary>
         /// <param name="name">The name of the SVG attribute.</param>
         internal SvgAttributeAttribute(string name)
-        {
-            Name = name;
-            NameSpace = SvgNamespace;
-        }
+            : this(name, SvgNamespace.UriString) { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SvgAttributeAttribute"/> class with the specified SVG attribute name and namespace.

--- a/Source/SvgDocument.cs
+++ b/Source/SvgDocument.cs
@@ -764,10 +764,7 @@ namespace Svg
 
             foreach (var ns in SvgAttributeAttribute.Namespaces)
             {
-                if (string.IsNullOrEmpty(ns.Key))
-                    writer.WriteAttributeString("xmlns", ns.Value);
-                else
-                    writer.WriteAttributeString("xmlns", ns.Key, null, ns.Value);
+                writer.WriteAttributeString("xmlns", ns.Key, null, ns.Value);
             }
 
             writer.WriteAttributeString("version", "1.1");

--- a/Source/SvgElementFactory.cs
+++ b/Source/SvgElementFactory.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Xml;
@@ -83,7 +83,7 @@ namespace Svg
 
             //Trace.TraceInformation("Begin CreateElement: {0}", elementName);
 
-            if (elementNS == SvgAttributeAttribute.SvgNamespace || string.IsNullOrEmpty(elementNS))
+            if (elementNS == SvgNamespace.UriString || string.IsNullOrEmpty(elementNS))
             {
                 if (elementName == "svg")
                 {
@@ -111,7 +111,7 @@ namespace Svg
             else
             {
                 // All non svg element (html, ...)
-                createdElement = new NonSvgElement(elementName);
+                createdElement = new NonSvgElement(elementName, elementNS);
                 SetAttributes(createdElement, reader, document);
             }
 
@@ -130,6 +130,10 @@ namespace Svg
 
             while (reader.MoveToNextAttribute())
             {
+                if (reader.LocalName.Equals("xmlns"))
+                {
+                    continue;    // skip the xmlns attribute (already processed via reader.NamespaceURI in CreateElement<T>)
+                }
                 if (reader.LocalName.Equals("style") && !(element is NonSvgElement))
                 {
                     var inlineSheet = cssParser.Parse("#a{" + reader.Value + "}");

--- a/Source/SvgNamespace.cs
+++ b/Source/SvgNamespace.cs
@@ -1,0 +1,9 @@
+﻿
+
+namespace Svg
+{
+    public static class SvgNamespace
+    {
+        public const string UriString = "http://www.w3.org/2000/svg";
+    }
+}


### PR DESCRIPTION
Handle the element namespace directly as a property of an element, rather than adding it to the collection of attributes.

#### Reference Issue
Towards Enhancement #693 

This was previously submitted as part of PR #694; now re-submitting in smaller commits.

#### What does this implement/fix? Explain your changes.

The XmlWriter class performs some stricter checks than the existing XmlTextWriter with respect to the handling of namespaces. The existing code specifies namespace simply by writing an "xmlns" attribute. However, with XmlWriter, this causes an exception to be thrown (similar to [this question on StackOverflow](https://stackoverflow.com/questions/23698767/the-prefix-cannot-be-redefined-from-to-url-within-the-same-start-element-t) )

#### Any other comments?
The changes impacted SvgAttributeAttribute.cs such that:

* the SVG namespace (http://www.w3.org/2000/svg) is no longer included in the list of namespaces that would be written into the root SvgFragment element from this list. Instead, all SvgElements are explicitly using this namespace as per SvgElement.cs
* the 'NamespaceAndName' method is no longer needed. Instead, XmlWriter.WriteAttributeString is called with the namespace and prefix to handle this. (again, in SvgElement.cs)

Since the SvgNamespace is needed more widely across SvgElement and SvgAttributeAttribute, I extracted it into its own static class.

All unit tests pass.

<!--
Thanks for contributing!
-->
