### PR TITLE
Added ElementInfo caching for faster SvgElement Creation

### DIFF
--- a/Source/Css/SvgElementOps.cs
+++ b/Source/Css/SvgElementOps.cs
@@ -16,8 +16,7 @@ namespace Svg.Css
 
         public Selector<SvgElement> Type(NamespacePrefix prefix, string name)
         {
-            var types = _elementFactory.AvailableElements.Where(e => e.ElementName.Equals(name)).Select(e => e.ElementType);
-            if (types.Any())
+            if (_elementFactory.AvailableElementsDictionary.TryGetValue(name, out var types))
             {
                 return nodes => nodes.Where(n => types.Contains(n.GetType()));
             }

--- a/Source/SvgElementFactory.cs
+++ b/Source/SvgElementFactory.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Xml;
@@ -14,29 +14,50 @@ namespace Svg
     /// </summary>
     internal class SvgElementFactory
     {
-        private List<ElementInfo> availableElements;
+        static SvgElementFactory()
+        {
+            // cache ElementInfo in static Field
+            var svgTypes = from t in typeof(SvgDocument).Assembly.GetExportedTypes()
+                where t.GetCustomAttributes(typeof(SvgElementAttribute), true).Length > 0
+                      && t.IsSubclassOf(typeof(SvgElement))
+                select new ElementInfo { ElementName = ((SvgElementAttribute)t.GetCustomAttributes(typeof(SvgElementAttribute), true)[0]).ElementName, ElementType = t };
+
+            availableElements = svgTypes.ToList();
+
+            // cache ElementInfo without Svg in static field
+            availableElementsWithoutSvg = availableElements
+                .Where(e => !e.ElementName.Equals("svg", StringComparison.OrdinalIgnoreCase))
+                .ToDictionary(e => e.ElementName, e => e);
+
+            // cache ElementInfo ElementTypes in static field
+            availableElementsDictionary = new Dictionary<string, List<Type>>();
+            foreach (var element in availableElements)
+            {
+                if (!availableElementsDictionary.TryGetValue(element.ElementName, out var list))
+                {
+                    list = new List<Type>();
+                    availableElementsDictionary[element.ElementName] = list;
+                }
+
+                list.Add(element.ElementType);
+            }
+        }
+
+        private static readonly Dictionary<string, List<Type>> availableElementsDictionary;
+        private static readonly Dictionary<string, ElementInfo> availableElementsWithoutSvg;
+        private static readonly List<ElementInfo> availableElements;
+
         private Parser cssParser = new Parser();
 
         /// <summary>
         /// Gets a list of available types that can be used when creating an <see cref="SvgElement"/>.
         /// </summary>
-        public List<ElementInfo> AvailableElements
-        {
-            get
-            {
-                if (availableElements == null)
-                {
-                    var svgTypes = from t in typeof(SvgDocument).Assembly.GetExportedTypes()
-                                   where t.GetCustomAttributes(typeof(SvgElementAttribute), true).Length > 0
-                                   && t.IsSubclassOf(typeof(SvgElement))
-                                   select new ElementInfo { ElementName = ((SvgElementAttribute)t.GetCustomAttributes(typeof(SvgElementAttribute), true)[0]).ElementName, ElementType = t };
+        public List<ElementInfo> AvailableElements => availableElements;
 
-                    availableElements = svgTypes.ToList();
-                }
-
-                return availableElements;
-            }
-        }
+        /// <summary>
+        /// Gets a list of available types that can be used when creating an <see cref="SvgElement"/>.
+        /// </summary>
+        internal Dictionary<string, List<Type>> AvailableElementsDictionary => availableElementsDictionary;
 
         /// <summary>
         /// Creates an <see cref="SvgDocument"/> from the current node in the specified <see cref="XmlTextReader"/>.
@@ -92,8 +113,7 @@ namespace Svg
                 else
                 {
                     ElementInfo validType;
-                    if (AvailableElements.Where(e => !e.ElementName.Equals("svg", StringComparison.OrdinalIgnoreCase))
-                        .ToDictionary(e => e.ElementName, e => e).TryGetValue(elementName, out validType))
+                    if (availableElementsWithoutSvg.TryGetValue(elementName, out validType))
                     {
                         createdElement = (SvgElement)Activator.CreateInstance(validType.ElementType);
                     }

--- a/Tests/Svg.UnitTests/PerformanceTest.cs
+++ b/Tests/Svg.UnitTests/PerformanceTest.cs
@@ -26,10 +26,11 @@ namespace Svg.UnitTests
         /// <summary>
         /// Load All W3CSvg Unit tests
         /// On My Machine this Unit Test went from 22 seconds down to 10 seconds. I set the Timeout
-        /// to 25 seconds to catch Performance regressions
+        /// to 25 seconds to catch Performance regressions On the Build Server it needs 9 seconds
+        /// So I can move down the timeout to 15 seconds
         /// </summary>
         [Test]
-        [Timeout(25000)]
+        [Timeout(15000)]
         public void LoadAllW3CSvg()
         {
             var svgPath = Path.Combine(AssemblyDirectory, "..", "..", "..", "..", "W3CTestSuite", "svg");

--- a/Tests/Svg.UnitTests/PerformanceTest.cs
+++ b/Tests/Svg.UnitTests/PerformanceTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO.Compression;
 using System.IO;
 using System.Text;
 using System.Reflection;
@@ -39,7 +40,18 @@ namespace Svg.UnitTests
                 {
                     for (int i = 0; i < 10; i++)
                     {
-                        SvgDocument.Open<SvgDocument>(file);
+                        using (var stream = File.OpenRead(file))
+                        {
+                            if (Path.GetExtension(file) == ".svgz")
+                            {
+                                var gzipStream = new GZipStream(stream, CompressionMode.Decompress);
+                                SvgDocument.Open<SvgDocument>(gzipStream);    
+                            }
+                            else
+                            {
+                                SvgDocument.Open<SvgDocument>(stream);    
+                            }
+                        }
                     }
                 }
                 catch (Exception e)

--- a/Tests/Svg.UnitTests/PerformanceTest.cs
+++ b/Tests/Svg.UnitTests/PerformanceTest.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Reflection;
+
+using NUnit.Framework;
+
+namespace Svg.UnitTests
+{
+    [TestFixture]
+    public class PerformanceTest 
+    {
+        public static string AssemblyDirectory
+        {
+            get
+            {
+                string codeBase = typeof(PerformanceTest).Assembly.CodeBase;
+                UriBuilder uri = new UriBuilder(codeBase);
+                string path = Uri.UnescapeDataString(uri.Path);
+                return Path.GetDirectoryName(path);
+            }
+        }
+
+        /// <summary>
+        /// Load All W3CSvg Unit tests
+        /// On My Machine this Unit Test went from 22 seconds down to 10 seconds. I set the Timeout
+        /// to 25 seconds to catch Performance regressions
+        /// </summary>
+        [Test]
+        [Timeout(25000)]
+        public void LoadAllW3CSvg()
+        {
+            var svgPath = Path.Combine(AssemblyDirectory, "..", "..", "..", "..", "W3CTestSuite", "svg");
+            var files = Directory.GetFiles(svgPath, "*.svg");
+            foreach (var file in files)
+            {
+                for (int i = 0; i < 10; i++)
+                {
+                    SvgDocument.Open<SvgDocument>(file);
+                }
+            }
+        }
+    }
+}

--- a/Tests/Svg.UnitTests/PerformanceTest.cs
+++ b/Tests/Svg.UnitTests/PerformanceTest.cs
@@ -35,9 +35,17 @@ namespace Svg.UnitTests
             var files = Directory.GetFiles(svgPath, "*.svg");
             foreach (var file in files)
             {
-                for (int i = 0; i < 10; i++)
+                try
                 {
-                    SvgDocument.Open<SvgDocument>(file);
+                    for (int i = 0; i < 10; i++)
+                    {
+                        SvgDocument.Open<SvgDocument>(file);
+                    }
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine($"Exception in svg file: {file} with Message: {e.Message}  {Environment.NewLine} Content: {Environment.NewLine} {File.ReadAllText(file)} ");
+                    throw;
                 }
             }
         }


### PR DESCRIPTION
This causes the Performance Test to finish in 10 seconds instead of 22 seconds without the optimizations.

#### Reference Issue
https://github.com/vvvv/SVG/issues/767

#### What does this implement/fix? Explain your changes.
I profiled a Mobile App that uses this svg library and the profiler showed that a large part of the parsing of Svg is spent in 
creating the ElementInfo, I cache it statically, because it can't change during loading.

#### Any other comments?
Added an unit test for performance that times out after 25 seconds. Maybe the timeout can be adjusted downwards.
On my machine this Unit Test runs in 10 seconds.
