### PR TITLE
Use maximum height value for region calculation

### DIFF
--- a/Source/Text/GdiFontDefn.cs
+++ b/Source/Text/GdiFontDefn.cs
@@ -48,7 +48,7 @@ namespace Svg
 
                 var location = new PointF(0f, 0f);
                 var size = System.Drawing.Size.Ceiling(g.MeasureString(text, _font, location, format));
-                var layoutRect = new RectangleF(location, size);
+                var layoutRect = new RectangleF(location, new SizeF(size.Width, 1000));
 
                 for (var s = 0; s <= (text.Length - 1) / 32; s++)
                 {


### PR DESCRIPTION
- this has been done before the fix for #741 and ensures
  that no invalid regions are created
- fixes #775

This is a minor change to the fix for #741 that broke some W3C examples.