### PR TITLE
Remove DynamicallyAccessedMemberTypes to improve trim/aot compatibility

### DIFF
--- a/Source/DataTypes/SvgAspectRatio.cs
+++ b/Source/DataTypes/SvgAspectRatio.cs
@@ -1,6 +1,5 @@
 using System;
 using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
 using Svg.DataTypes;
 
 namespace Svg
@@ -55,15 +54,10 @@ namespace Svg
             return MemberwiseClone();
         }
 
-#if NET6_0_OR_GREATER
-        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, typeof(SvgPreserveAspectRatioConverter))]
-        [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "DynamicDependency keeps converter safe")]
-        [UnconditionalSuppressMessage("AOT", "IL3050")]
-#endif
-        public override string ToString()
-        {
-            return TypeDescriptor.GetConverter(typeof(SvgPreserveAspectRatio)).ConvertToString(this.Align) + (Slice ? " slice" : "");
-        }
+public override string ToString()
+{
+    return Align.ToString() + (Slice ? " slice" : "");
+}
     }
 
     [TypeConverter(typeof(SvgPreserveAspectRatioConverter))]

--- a/Source/DataTypes/SvgAspectRatio.cs
+++ b/Source/DataTypes/SvgAspectRatio.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.ComponentModel;
 using Svg.DataTypes;
 
@@ -54,10 +54,10 @@ namespace Svg
             return MemberwiseClone();
         }
 
-public override string ToString()
-{
-    return Align.ToString() + (Slice ? " slice" : "");
-}
+        public override string ToString()
+        {
+            return Align.ToString() + (Slice ? " slice" : "");
+        }
     }
 
     [TypeConverter(typeof(SvgPreserveAspectRatioConverter))]

--- a/Source/DataTypes/SvgPoint.cs
+++ b/Source/DataTypes/SvgPoint.cs
@@ -1,4 +1,4 @@
-using Svg.DataTypes;
+﻿using Svg.DataTypes;
 
 namespace Svg
 {
@@ -39,13 +39,13 @@ namespace Svg
             return base.GetHashCode();
         }
 
-public SvgPoint(string x, string y)
-{
-    var converter = new SvgUnitConverter();
+        public SvgPoint(string x, string y)
+        {
+            var converter = new SvgUnitConverter();
 
-    this.x = (SvgUnit)converter.ConvertFrom(x)!;
-    this.y = (SvgUnit)converter.ConvertFrom(y)!;
-}
+            this.x = (SvgUnit)converter.ConvertFrom(x)!;
+            this.y = (SvgUnit)converter.ConvertFrom(y)!;
+        }
 
         public SvgPoint(SvgUnit x, SvgUnit y)
         {

--- a/Source/DataTypes/SvgPoint.cs
+++ b/Source/DataTypes/SvgPoint.cs
@@ -1,5 +1,3 @@
-using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
 using Svg.DataTypes;
 
 namespace Svg
@@ -41,17 +39,13 @@ namespace Svg
             return base.GetHashCode();
         }
 
-#if NET6_0_OR_GREATER
-        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, typeof(SvgUnitConverter))]
-        [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "DynamicDependency keeps converter safe")]
-#endif
-        public SvgPoint(string x, string y)
-        {
-            TypeConverter converter = TypeDescriptor.GetConverter(typeof(SvgUnit));
+public SvgPoint(string x, string y)
+{
+    var converter = new SvgUnitConverter();
 
-            this.x = (SvgUnit)converter.ConvertFrom(x)!;
-            this.y = (SvgUnit)converter.ConvertFrom(y)!;
-        }
+    this.x = (SvgUnit)converter.ConvertFrom(x)!;
+    this.y = (SvgUnit)converter.ConvertFrom(y)!;
+}
 
         public SvgPoint(SvgUnit x, SvgUnit y)
         {


### PR DESCRIPTION
Remove DynamicallyAccessedMemberTypes to improve trim/aot compatibility

These attributes were added as part of trim annotations in https://github.com/svg-net/SVG/pull/1184 

This PR simplifies the code to remove the need for these attrbutes.

@maxkatz6 am I missing something here? You mentioned in the above PR that "It would be possible to avoid DynamicDependency attributes, by refactoring code to not depend on TypeDescriptors" but the attributes were only on two little types and the fixes seem very straightforward.